### PR TITLE
[BUGFIX] getViableItems of editors plugin does not resolve its return va...

### DIFF
--- a/common/src/webida/plugins/editors/viable-menu-items.js
+++ b/common/src/webida/plugins/editors/viable-menu-items.js
@@ -535,7 +535,9 @@ define(['./plugin',
             } else {
                 deferred.resolve(items);
             }
-        }
+        } else { 
+            deferred.resolve(null);
+        } 
 
         return deferred;
     }


### PR DESCRIPTION
...lue (a deferred) if the current editor is not a code editor, which blocks the process of popping up its context menu.

[DESC]