### PR TITLE
[BUGFIX] "handledFileNames" spec. added to webida.common.editors:editor extension point

### DIFF
--- a/apps/ide/src/plugins/codeeditor/plugin.json
+++ b/apps/ide/src/plugins/codeeditor/plugin.json
@@ -10,6 +10,7 @@
             "fileValueRequired" : true,
             "handledFileExt" : [ ".*" ],
             "handledMimeTypes" : [],
+            "handledFileNames" : [],
             "unhandledFileExt" : [],
             "unhandledMimeTypes" : [ "audio/.*", "video/.*", "image/.*" ]
         },


### PR DESCRIPTION
[example of plugin.json for plugin.xml]

{
    "name": "xmleditor",
    "description": "XML editor",
    "version": "0.1.0",
    "requirement": "webida.common.editors",
    "extensions" : {

        "webida.common.editors:editor" : {
            "name" : "XML editor",
            "fileValueRequired" : true,
            "handledFileExt" : [],
            "handledMimeTypes" : [],
            "handledFileNames" : [ "plugin.xml" ],
            "unhandledFileExt" : [],
            "unhandledMimeTypes" : []
        }
    }
}