### PR TITLE
[BUGFIX] deleteMyApps(), setAppInfo() api bug.

### DIFF
--- a/common/src/webida/webida-0.3.js
+++ b/common/src/webida/webida-0.3.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2015 S-Core Co., Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -2405,11 +2405,6 @@ var ENV_TYPE;
     */
     mod.AppService.prototype.setAppInfo = function (appid, domain, apptype, name, desc, srcurl, callback) {
         function restApi() {
-            if (!mod.app.isValidAppType(apptype)) {
-                callback({result: 'failed', reason: 'Invalid apptype'});
-                return;
-            }
-
             var data = {
                 appid: appid,
                 newdomain: domain,
@@ -2418,7 +2413,16 @@ var ENV_TYPE;
                 newdesc: desc
             };
 
-            if (srcurl) { data.newsrcurl = srcurl; }
+            if (typeof srcurl === 'function') {
+                callback = srcurl;
+            }  else {
+                data.newsrcurl = srcurl;
+            }
+
+            if (!mod.app.isValidAppType(apptype)) {
+                callback({result: 'failed', reason: 'Invalid apptype'});
+                return;
+            }
 
             ajaxCall({
                 url: mod.conf.appApiBaseUrl + '/changeappinfo',
@@ -2542,7 +2546,7 @@ var ENV_TYPE;
                     return;
                 }
 
-                mod.app.deleteApp(infos[i].domain, function (err) {
+                mod.app.deleteApp(infos[i].appid, function (err) {
                     count++;
 
                     if (escape) {


### PR DESCRIPTION
* deleteMyApps() api bug : When calling deleteApp() in deleteMyApps() api, appid should be passed instead of domain.
* setAppInfo() api bug : callback argument is undefined if srcurl argument is omitted.

Signed-off-by: Sangjin Kim <sangjin3.kim@samsung.com>