### PR TITLE
[BUGFIX] A 'getViableItems' does not resolve its returned promise in …

### DIFF
--- a/common/src/webida/plugins/editors/viable-menu-items.js
+++ b/common/src/webida/plugins/editors/viable-menu-items.js
@@ -270,7 +270,9 @@ define(['./plugin',
             } else {
                 deferred.resolve(items);
             }
-        }
+        } else { 
+            deferred.resolve(null);
+        } 
 
         return deferred;
     }


### PR DESCRIPTION
…a case, which results in whole disabled items in the top-level menu in that case.

[DESC]