### PR TITLE
[BUGFIX] Fix to show correct error message for duplicate account

### DIFF
--- a/apps/site/src/js/main.js
+++ b/apps/site/src/js/main.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2015 S-Core Co., Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -154,7 +154,9 @@ define([
                     //var e = JSON.parse(err);
                     console.log('signup failed', err);
 
-                    if (err === 'Email is already used') {
+                    var match = err.match(/Email (.*) is already used/);
+                    if (match) {
+                        // match[1] is email
                         toastr.error('"' + email + '" is already used!');
                         $('#email').focus();
                     }


### PR DESCRIPTION
[DESC.]
This change fixes to show correct error message for duplicate account by matching with regular expression.
Currently, the error is shown just as "Unknown".