### PR TITLE
[TASK] Remove description user input when creating a workspace

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -136,8 +136,10 @@
                         <li><label for="ws-name-input">Workspace name</label></li>
                         <li><input type="text" id="ws-name-input" placeholder="Enter name for new workspace"></li>
                         <li class="dialog_message" id="adddlg_message"></li>
+                        <!-- TODO: Description is not available because workspace information is not stored into separate storage. Workspace is just a directory now.
                         <li><label for="ws-desc-input">Description</label></li>
                         <li><input type="text" id="ws-desc-input" placeholder="Enter workspace description"></li>
+                        -->
                         <li><button class="btn green max submit"><span>Create</span></button></li>
                     </ul>
                 </div>


### PR DESCRIPTION
[DESC.]
Description is not available because workspace information is not stored into separate storage like a file. Workspace is just a directory now, so requesting workspace description to user is useless and confusing.