### PR TITLE
[TASK] Use unique class selector for toolbar icon

### DIFF
--- a/common/src/webida/plugins/workbench/command-system/toolbar.js
+++ b/common/src/webida/plugins/workbench/command-system/toolbar.js
@@ -24,8 +24,8 @@
  *   toolbar.js
  */
 
-define(['webida-lib/plugin-manager-0.1',                // pm
-        'external/lodash/lodash.min',               // _
+define(['webida-lib/plugin-manager-0.1', // pm
+        'external/lodash/lodash.min',    // _
         'dojo',                          // dojo
         'dojo/on',                       // on
         'dojo/dom-style',                // domStyle
@@ -46,7 +46,7 @@ define(['webida-lib/plugin-manager-0.1',                // pm
         'dijit/MenuItem',                // MenuItem
         'dijit/MenuSeparator',           // MenuSeparator
         './MenuItemTree',                // MenuItemTree
-        'external/toastr/toastr.min'                         // toastr
+        'external/toastr/toastr.min'     // toastr
        ],
 function (pm,
           _,
@@ -106,12 +106,15 @@ function (pm,
         var iconNormal = icons;
 
         if (iconNormal) {
+            var menuitem = item.attr('data-menuitem');
+            // convert id to valid class name e.g. /&File/&New/&File -> __File__New__File
+            var iconClass = menuitem.replace(/&/g, '').replace(/\//g, '__').replace(/ /g, '_') + '_wticons';
             var img = '<style type="text/css">' +
-                        '.' + item.id + '_wticons {' +
+                        '.' + iconClass + ' {' +
                             'background-image: url("' + iconNormal + '");' +
                         '}' +
                       '</style>';
-            var imgClasses = item.id + '_wticons webida-tool-bar-icon ' +
+            var imgClasses = iconClass + ' webida-tool-bar-icon ' +
                              'webida-tool-bar-icon-normal';
 
             img = img + '<img class="' + imgClasses + '"' +
@@ -201,6 +204,8 @@ function (pm,
                         if (cmndInfo && cmndInfo.toolbar) {
                             // create toolbar item
                             item = new Button();
+                            // set unique identifier for toolbar icon
+                            item.attr('data-menuitem', ploc + menuItemName);
 
                             // tooltip setting
                             tooltip = cmndInfo.toolbar.tooltip ?
@@ -254,6 +259,7 @@ function (pm,
                         if (cmndInfo && cmndInfo.toolbar) {
                             // create toolbar item
                             item = new ComboButton();
+                            item.attr('data-menuitem', ploc + menuItemName);
 
                             // tooltip setting
                             tooltip = cmndInfo.toolbar.tooltip ?


### PR DESCRIPTION
Currently, toolbar icon has a class name like ".dijit_form_Button_0_wticons" for 'New File'.
Amd if a user wants to override the icon for it, he wrote a rule like ".dijit_form_Button_0_wticons { his new file image } !important".

But the index can be changed by adding extension toolbars.
For example, 'New Project' has index 0 and 'New File' has index 1. In that case, he should modify above rule to ".dijit_form_Button_1_wticons { his new file image } !important".

So, I changed the unique class selector derived from menu item path like ".__File__New__File_wticons".