### PR TITLE
[enhancement] #205 Quit menu change when a dirty file exist

### DIFF
--- a/common/src/webida/app.js
+++ b/common/src/webida/app.js
@@ -578,10 +578,12 @@ define(['webida-lib/util/browserInfo',
      *      (e.g. unsaved changes in a file).
      * @returns {undefined}
      */
-
-    function registerBeforeUnloadChecker(checker) {
-        var key = 'key' + Object.keys(beforeUnloadCheckers).length;
+    function registerBeforeUnloadChecker(key, checker) {
         beforeUnloadCheckers[key] = checker;
+    }
+
+    function unregisterBeforeUnloadChecker(key) {
+        delete beforeUnloadCheckers[key];
     }
 
     /**
@@ -788,6 +790,13 @@ define(['webida-lib/util/browserInfo',
      * @type {register_before_unload_checker}
      */
     exports.registerBeforeUnloadChecker = registerBeforeUnloadChecker;
+
+
+    /**
+     * A function that unregisters a callback which checks whether Webida App can safely be unloaded
+     * @type {unregister_before_unload_checker}
+     */
+    exports.unregisterBeforeUnloadChecker = unregisterBeforeUnloadChecker;
 
     /**
      * A function that registers a callback which produces an object encoding a status of a part of Webida App.

--- a/common/src/webida/plugins/editors/plugin.js
+++ b/common/src/webida/plugins/editors/plugin.js
@@ -734,11 +734,7 @@ define([
             }
         };
 
-        topic.publish('view.quit', event, function() {
-            if (event.quitable) {
-                vc._remove(event.view, true);
-            }
-        });
+        topic.publish('view.quit', event, function () {});
     };
 
     editors.saveFile = function(option) {


### PR DESCRIPTION
when a dirty file exists, dialog boxes between File>Close and File>Quit are different.

Signed-off-by: Minsung Jin <minsung.jin@samsung.com>