### PR TITLE
[BUGFIX] fix id_rsa path to have a valid absolute path '/.userinfo/id…

### DIFF
--- a/common/src/webida/plugins/git/git-commands.js
+++ b/common/src/webida/plugins/git/git-commands.js
@@ -1198,7 +1198,7 @@ define(['require',
                 if (value === '' || TargetTextBox.get('value') === '') {
                     cloneButton.set('disabled', true);
                 } else if (value.match(/^ssh:.*/)) {
-                    fsCache.exists('.userinfo/id_rsa', function (err, exists) {
+                    fsCache.exists('/.userinfo/id_rsa', function (err, exists) {
                         if (err) {
                             gitviewlog.error(GIT_DIR, 'clone', err);
                         } else {


### PR DESCRIPTION
…_rsa'

[DESC.]
This change fixes id_rsa path as '/.userinfo/id_rsa' from '.userinfo/id_rsa'.
Previously when a user sets target url to be cloned, the following error message is shown.
The path ".userinfo/id_rsa" is not a valid absolute path.