### PR TITLE
[BUGFIX] #162 Editor resizing related refactoring (bug fix)

### DIFF
--- a/common/src/webida/plugins/workbench/views-controller.js
+++ b/common/src/webida/plugins/workbench/views-controller.js
@@ -578,11 +578,7 @@ define([
 
             aspect.before(bottomSplitter, '_startDrag', function () {
                 topic.publish('editor-panel-resize');
-            });
-            
-            aspect.after(this._topContainer, '_layoutChildren', function () {
-                topic.publish('editor-container-layout-changed');
-            });
+            });         
 
             var vcList;
 


### PR DESCRIPTION
[DESC.] In '#317 Editors are not re-sized for size changes within the editor area', duplicated operation is removed.