### PR TITLE
[FEATURE] 1) support reading binary file. 2) add fallback for no cookie

### DIFF
--- a/common/src/webida/FSCache-0.1.js
+++ b/common/src/webida/FSCache-0.1.js
@@ -1147,8 +1147,12 @@ function (webida, SortedArray, pathUtil, _, URI, declare, topic) {
             },
 
             // readFile
-            readFile : function (target, cb) {
+            readFile : function (target, responseType, cb) {
                 var targetNode;
+                if (!cb) {
+                    cb = responseType;
+                    responseType = '';
+                }
                 function checkValidReadFile() {
                     var ret = checkTargetPath(target, true);
                     if (isError(ret)) {
@@ -1188,18 +1192,19 @@ function (webida, SortedArray, pathUtil, _, URI, declare, topic) {
                 if (err) {
                     setTimeout(cb.bind(null, err), 0);
                 } else {
+                    // FIXME: cache and compare responseType too
                     if (withinCache(target)) {
                         var content;
                         if (targetNode === undefined ||
                             (content = targetNode.content) === undefined ||
                             targetNode.contentInvalidated) {
-                            mount.readFile(target, callback);
+                            mount.readFile(target, responseType, callback);
                         } else {
                             console.assert(content !== null);
                             setTimeout(cb.bind(null, null, content), 0);
                         }
                     } else {
-                        mount.readFile(target, cb);
+                        mount.readFile(target, responseType, cb);
                     }
                 }
             },


### PR DESCRIPTION
1) support reading binary file
Current FileSystem.readFile() API always assumes text file and uses XMLHttpRequest.responseText.
It's required to set XHR.responseType and use XHR.response for reading binary file.
This added additional argument responseType to readFile() and caller can determine the file type.

2) add fallback for the failure of getting cookie
This change adds fallback when the cookie value for Auth host is empty.
The cookie might not be set when a resource is cached and served by Proxy server.
So in that case, I try to get Auth host by window.location value.

And this change also adds a step for getting webidaHost.
Currently, if the cookie is not set, /isloggedin call is requested to 'https://webiga.org'.
So this adds a step to get a host by window.location value.

Change-Id: I35f38d9ab45bbde84bf0601cf33fc9151eeaea93