### PR TITLE
[BUGFIX] #358 Shortcut key not working on "MultiViewerExampleEditor"

### DIFF
--- a/apps/ide/src/plugins/webida.editor.example.multi-viewer/MultiViewerExampleEditorPart.js
+++ b/apps/ide/src/plugins/webida.editor.example.multi-viewer/MultiViewerExampleEditorPart.js
@@ -32,6 +32,7 @@
 define([
     'dojo/topic',
     'dijit/layout/ContentPane',
+    'external/lodash/lodash.min',
     'webida-lib/util/genetic', 
     'webida-lib/util/logger/logger-client',
     'webida-lib/util/loadCSSList',
@@ -48,6 +49,7 @@ define([
 ], function(
     topic,
     ContentPane,
+    _,
     genetic, 
     Logger,
     loadCSSList,
@@ -235,6 +237,7 @@ define([
                 });
 
                 //4. Listen to model
+                /* jshint ignore:start */
                 doc.on(PartModel.CONTENTS_CHANGE, function(doc, sender) {
                     //TODO getFile() will be removed in webida 1.5.0
                     //Temp Code
@@ -242,6 +245,7 @@ define([
                     editors.refreshTabTitle(that.getFile());
                     topic.publish('file.content.changed', file.getPath(), file.getContents());
                 });
+                /* jshint ignore:end */
 
                 //5. For the concurrent editing, listen to the model
                 // Note that, when user select the tab,

--- a/apps/ide/src/plugins/webida.editor.example.multi-viewer/MultiViewerExampleEditorPart.js
+++ b/apps/ide/src/plugins/webida.editor.example.multi-viewer/MultiViewerExampleEditorPart.js
@@ -142,6 +142,13 @@ define([
                     TextEditorPart.moveForth();
                 }
             });
+            
+            viewer.addEventListener('save', function() {
+                require(['dojo/topic'], function(topic) {
+                    topic.publish('#REQUEST.saveFile');
+                });
+            });
+
             viewer.setMode(this.file.extension);
             viewer.setTheme('webida');
         },

--- a/common/src/webida/plugins/git/git-commands.js
+++ b/common/src/webida/plugins/git/git-commands.js
@@ -4041,7 +4041,13 @@ define(['require',
                 readOnly: true,
                 styleActiveLine: true,
                 mode: 'scheme',
-                theme: theme
+                theme: theme,
+                extraKeys: {
+                    "Esc": function (c) {
+                        compareDialog.destroyRecursive();
+                        workbench.focusLastWidget();
+                    }
+                }
             });
 
             mergeView.rightOriginal().setSize('100%', height);
@@ -4500,7 +4506,13 @@ define(['require',
                         value: result,
                         styleActiveLine: true,
                         mode: 'scheme',
-                        theme: theme
+                        theme: theme,
+                        extraKeys: {
+                            "Esc": function (c) {
+                                blameDialog.destroyRecursive();
+                                workbench.focusLastWidget();
+                            }
+                        }
                     });
 
                     blameLog.forEach(function (blame, idx) {

--- a/common/src/webida/widgets/dialogs/buttoned-dialog/ButtonedDialog.js
+++ b/common/src/webida/widgets/dialogs/buttoned-dialog/ButtonedDialog.js
@@ -24,10 +24,16 @@
 
 define(['dojo/_base/declare',
         'dojo/aspect',
+        'dojo/on',
         'dijit/Dialog',
         'dijit/registry',
-        'dojo/domReady!'],
-function (declare, aspect, Dialog, registry) {
+        'dojo/domReady!'
+], function (
+       declare,
+       aspect,
+       on,
+       Dialog,
+       registry) {
     'use strict';
 
     var dialogNum = 0;
@@ -153,6 +159,14 @@ function (declare, aspect, Dialog, registry) {
                     }
                 });
             }
+
+            on(document.body, 'keydown', function (evt) {
+                if (evt.keyCode === 27) {   // ESC
+                    if (Dialog._DialogLevelManager.isTop(self) === true) {
+                        self.hide();
+                    }
+                }
+            });
 
             aspect.before(this, 'onLoad', function () {
                 function setWidthsAndClickHandlers(buttonSpecs, level) {


### PR DESCRIPTION
[DESC.] Shortcut key not working on "MultiViewerExampleEditor's source editor tab " problem is fixed. MultiViewerExampleEditor should initialize listeners as CodeEditorPart and TextEditorPart.