### PR TITLE
[BUGFIX] #374 Cannot move or copy a file with a space on its name.

### DIFF
--- a/common/src/webida/plugins/workspace/Node.js
+++ b/common/src/webida/plugins/workspace/Node.js
@@ -416,6 +416,7 @@ define(['require',
                     var finalName;
                     function handleFile() {
                         var fn = action === 'move' ? fsCache.move: fsCache.copy;
+                        finalName = finalName.replace(/&nbsp;/g, ' ');
                         var newFile = targetPath + finalName;
                         fn(entry.path, newFile, function (err) {
                             if (err) {
@@ -1532,11 +1533,13 @@ define(['require',
                 node.iconNode.innerHTML = '';
                 var stateSetIconClassMap = wv.getStateSetIconClassMap();
                 for (var stateSet in stateSetIconClassMap) {
-                    var overlayIconClass = stateSetIconClassMap[stateSet][that.overlayIconInfo[stateSet]];
-                    if (overlayIconClass) {
-                        var overlayElement = document.createElement('span');
-                        overlayElement.className = overlayIconClass;
-                        node.iconNode.appendChild(overlayElement);
+                    if (stateSetIconClassMap.hasOwnProperty(stateSet)) {
+                        var overlayIconClass = stateSetIconClassMap[stateSet][that.overlayIconInfo[stateSet]];
+                        if (overlayIconClass) {
+                            var overlayElement = document.createElement('span');
+                            overlayElement.className = overlayIconClass;
+                            node.iconNode.appendChild(overlayElement);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
Fixed that A file with space in file's name is not moved and copied at the workspace

Signed-off-by: Minsung Jin <minsung.jin@samsung.com>