### PR TITLE
[ENHANCEMENT] #327 Quit does not work when a user access IDE directly

### DIFF
--- a/common/src/webida/plugins/editors/workbench-panels.js
+++ b/common/src/webida/plugins/editors/workbench-panels.js
@@ -312,8 +312,14 @@ define([
 
                 try {
                     window.focus();
-                    window.opener = window;
-                    window.close();
+
+                    if (!window.opener) {
+                        alert('Quit does not work when IDE was opened by a direct URL.\n' +
+                              'Please close the browser tab to quit the IDE.');
+                    } else {
+                        //window.opener = window;
+                        window.close();
+                    }
                 } catch (e) {
                     logger.log('First try to close App failed', e);
 


### PR DESCRIPTION
Alert to miss a window.opener

Signed-off-by: Minsung Jin <minsung.jin@samsung.com>