### PR TITLE
[BUGFIX] #404 Fix workspace view flickers

### DIFF
--- a/common/src/webida/plugins/workspace/plugin.js
+++ b/common/src/webida/plugins/workspace/plugin.js
@@ -326,10 +326,6 @@ define([
                 }
             },
 
-            onFocus: function() {
-                this.focus();
-            },
-
             onBlur: function() {
                 if (focusedNode) {
                     $(focusedNode).removeClass('focused');


### PR DESCRIPTION
[DESC.] Workspace view flickers when selecting a new resource while last
selected resource is not shown by scrolling.  Workspace view tree shows
last selected node as default behavior of focus event. This change
ignores focus event because that's the usual way of handling focus in
usual file trees such as Windows Explorer, Chrome DevTools, Eclipse,
etc.

Change-Id: Ia02990621c4001b3e9254925809a3ee6c34ce9c7
Signed-off-by: WooYoung Cho <wy1.cho@samsung.com>