### PR TITLE
[IMPROVEMENT] improvement on preference plugin

### DIFF
--- a/apps/deploy/plugins/paas-webida/plugin.js
+++ b/apps/deploy/plugins/paas-webida/plugin.js
@@ -521,6 +521,11 @@ define([
                                 console.log('deployApp : ' + err);
                                 var app = reg.byNode(parent);
                                 showAppPane.removeChild(app);
+                                webida.app.deleteApp(appID, function (err) {
+                                    if (err) {
+                                        toastr.error(err);
+                                    }
+                                });
                             } else {
                                 icon = $(parent).find('.table-title-newappcancel');
                                 $(icon).removeClass('table-title-newappcancel-block');

--- a/apps/ide/src/plugins/webida.preference/layout/preferences-tree.html
+++ b/apps/ide/src/plugins/webida.preference/layout/preferences-tree.html
@@ -4,7 +4,7 @@
          data-id="<%= c.id %>"
          data-parent-id="<%= c.parent %>"
          style="display: <% if (!c.parent) { %> block <% } else { %> none <% } %>;">
-        <span style="width: <%= (c.depth * 15) %>px; display: inline-block;"></span>
+        <span style="width: <%= (c.hierarchies.length * 15) %>px; display: inline-block;"></span>
         <span class="preferenceview-category-item__tree <% if(c.hasChild && c.expanded) { %> expanded <% } else if (c.hasChild && !c.expanded) { %> collapsed <% } else { %> none <% } %>"
               data-id="<%= c.id %>">
         </span>

--- a/apps/ide/src/plugins/webida.preference/pages/SimplePage.js
+++ b/apps/ide/src/plugins/webida.preference/pages/SimplePage.js
@@ -122,7 +122,13 @@ define([
             PreferencePage.prototype.onPageRemoved.call(this);
         },
         reload: function () {
-
+            var self = this;
+            _.forEach(this.components, function (comp) {
+                var key = comp.get('id');
+                if (key) {
+                    comp.set('value', self.store.getValue(key), false);
+                }
+            });
         },
         _addGroup: function (title) {
             $('<h2>' + title + '</h2>').appendTo(this.ui);
@@ -190,6 +196,7 @@ define([
 
                     var comboBox = new ComboBox({
                         //name: "state",
+                        id: key,
                         store: dataStore,
                         searchAttr: 'name',
                         value: currentValue,
@@ -212,9 +219,10 @@ define([
                     var slider = $('<div>').appendTo(wrapper);
 
                     slider = new HorizontalSlider({
+                        id: key,
                         minimum: opt.min,
                         maximum: opt.max,
-                        intermediateChanges: true,
+                        intermediateChanges: false,
                         style: 'width: 300px',
                         discreteValues: (opt.max - opt.min + 1),
                         value: value,
@@ -250,6 +258,7 @@ define([
                     br.appendTo(wrapper);
 
                     var text = new TextBox({
+                        id: key,
                         value: value,
                         style: 'margin-top: 5px; margin-bottom: 5px; margin-left: 5px;',
                         onChange: function (value) {

--- a/apps/ide/src/plugins/webida.preference/preference-manager.js
+++ b/apps/ide/src/plugins/webida.preference/preference-manager.js
@@ -166,7 +166,6 @@ define([
             }).then(function (fileInfo) {
                 var extensionsForScope = _getExtensionsByScope(fileInfo.scopeName);
                 _.forEach(extensionsForScope, function (extension) {
-                    //console.log('[4] makestore start', fileInfo, extension.defaultValues);
                     var store = new Store(
                         extension.id,
                         fileInfo.scopeName,
@@ -292,8 +291,7 @@ define([
                 });
             });
         })).then(function (invalidMsgs) {
-            // TODO handle invalid messages
-            callback(invalidMsgs);
+            callback(invalidMsgs.join(' '));
         });
     };
 

--- a/apps/ide/src/plugins/webida.preference/preference-store.js
+++ b/apps/ide/src/plugins/webida.preference/preference-store.js
@@ -89,7 +89,7 @@ define([
             dirty = true;
             this.invalidMessage = this.validator(key, this.currentValues[key]);
             valid = !this.invalidMessage;
-            this.setStatus({dirty: dirty, valid: valid});
+            this.setStatus({dirty: dirty, valid: valid, override: true});
         }
     };
 

--- a/apps/ide/src/plugins/webida.preference/preference-store.js
+++ b/apps/ide/src/plugins/webida.preference/preference-store.js
@@ -38,7 +38,7 @@ define([
             valid: true,
             override: false
         }
-        this.invalidMessage = {};
+        this.invalidMessage = '';
 
         this.defaultValues = {};
         this.appliedValues = {};
@@ -123,9 +123,10 @@ define([
     PreferenceStore.prototype.setStatus = function (status) {
         // status ['dirty', 'valid', 'override']
         var changedStatus = getRealChangedValues(this.status, status);
-        console.log('beforeSetStatus: ', this.id, this.scope, this.status, status);
         _.extend(this.status, changedStatus);
-        console.log('afterSetStatus: ', this.id, this.scope, this.status);
+        if (this.status.valid) {
+            this.invalidMessage = '';
+        }
         if (Object.keys(changedStatus).length > 0) {
             // listener
             for (var i=0; i<this.statusChangeListener.length; i++) {

--- a/apps/ide/src/plugins/webida.preference/style/style.css
+++ b/apps/ide/src/plugins/webida.preference/style/style.css
@@ -1,10 +1,10 @@
 .dim {
     position: absolute;
-    top: 37px;
+    top: 38px;
     left: 0;
     width: 100%;
     height: 378px;
-    background-color: rgba(30, 30, 30, 0.3);
+    background-color: rgba(245,250,255,0.6);
     z-index: 2;
 }
 

--- a/apps/ide/src/plugins/webida.preference/view-controller.js
+++ b/apps/ide/src/plugins/webida.preference/view-controller.js
@@ -25,6 +25,7 @@ define([
     'webida-lib/util/logger/logger-client',
     'dojo/on',
     'dijit/registry',
+    'plugins/webida.notification/notification-message',
     './preference-manager',
     './tree-view-controller',
     'webida-lib/widgets/dialogs/buttoned-dialog/ButtonedDialog',
@@ -35,6 +36,7 @@ define([
     Logger,
     on,
     reg,
+    topic,
     preferenceManager,
     treeViewController,
     ButtonedDialog,
@@ -56,8 +58,8 @@ define([
     var invalidStores = [];
 
     var PAGE_CLASS = {
-        'DefaultPage': 'plugins/webida.preference/pages/PreferencePage',
-        'SimplePage': 'plugins/webida.preference/pages/SimplePage'
+        DefaultPage: 'plugins/webida.preference/pages/PreferencePage',
+        SimplePage: 'plugins/webida.preference/pages/SimplePage'
     };
 
     var onChangingPage = false;
@@ -72,7 +74,7 @@ define([
         }
         if (status) {
             if (status.override !== undefined) {
-                reg.byId("preference-override").set('checked', status.override);
+                reg.byId('preference-override').set('checked', status.override);
             }
             if (status.valid !== undefined) {
                 if (!status.valid) {
@@ -91,6 +93,7 @@ define([
     function _onChangeTreeSelection(node) {
         if(!onChangingPage) {
             onChangingPage = true;
+            treeViewController.blockTreeSelection(true);
             // get preference store
             var store = preferenceManager.getStore(node.id, scope, scopeInfo);
             // get extension's meta
@@ -120,6 +123,7 @@ define([
                 subContentArea.appendChild(currentPage.getPage());
                 currentPage.onPageAppended();
                 onChangingPage = false;
+                treeViewController.blockTreeSelection(false);
             });
         }
     }
@@ -127,8 +131,8 @@ define([
     function _initializeContentArea(node, store) {
 
         function __dim(override) {
-            if(!override) {
-                if($(subContentArea).find('.dim').length === 0) {
+            if (!override) {
+                if ($(subContentArea).find('.dim').length === 0) {
                     $(subContentArea).append($('<div class="dim"></div>'));
                 }
             } else {
@@ -136,7 +140,7 @@ define([
             }
         }
 
-        var overrideCheckbox = reg.byId("preference-override");
+        var overrideCheckbox = reg.byId('preference-override');
         $(titleArea).find('h1').text(node.name);
         if (preferenceManager.getParentStore(store)) {
             overrideCheckbox.set('checked', store.status.override);
@@ -154,7 +158,9 @@ define([
             }),
             on($('#apply-preference').get(0), 'click', function () {
                 currentPage.store.apply(function (invalidMessage) {
-                    // TODO handle error
+                    if (invalidMessage) {
+                        topic.warning(invalidMessage);
+                    }
                 });
             }),
             on(overrideCheckbox, 'change', function () {
@@ -206,7 +212,9 @@ define([
                 methodOnEnter: null,
                 saveClose: function () {
                     preferenceManager.saveAllPreference(scope, function (invalidMessages) {
-                        // TODO handle error
+                        if (invalidMessages.trim()) {
+                            topic.warning(invalidMessages);
+                        }
                         preferenceDlg.hide();
                     });
                 },
@@ -218,7 +226,9 @@ define([
                     treeViewController.onPageRemoved();
                     preferenceDlg.destroyRecursive();
                     preferenceManager.flushPreference(scope, scopeInfo, function (err) {
-                        // TODO handle error
+                        if (err) {
+                            topic.error(err);
+                        }
                         module.isOpened = false;
                     });
                 }

--- a/apps/ide/src/plugins/webida.preference/view-controller.js
+++ b/apps/ide/src/plugins/webida.preference/view-controller.js
@@ -65,11 +65,10 @@ define([
     var onChangingPage = false;
 
     function _onStoreStatusChanged(status) {
+        reg.byId('restore-preference').set('disabled', !currentPage.store.status.override);
         if (currentPage.store.status.dirty) {
-            reg.byId('restore-preference').set('disabled', false);
             reg.byId('apply-preference').set('disabled', !currentPage.store.status.valid);
         } else {
-            reg.byId('restore-preference').set('disabled', true);
             reg.byId('apply-preference').set('disabled', true);
         }
         if (status) {
@@ -131,21 +130,23 @@ define([
     function _initializeContentArea(node, store) {
 
         function __dim(override) {
-            if (!override) {
-                if ($(subContentArea).find('.dim').length === 0) {
-                    $(subContentArea).append($('<div class="dim"></div>'));
+            if (!$('.preference-override-box').hasClass('hidden')) {
+                if (!override) {
+                    if ($(subContentArea).find('.dim').length === 0) {
+                        $(subContentArea).append($('<div class="dim"></div>'));
+                    }
+                } else {
+                    $(subContentArea).find('.dim').remove();
                 }
-            } else {
-                $(subContentArea).find('.dim').remove();
             }
         }
 
         var overrideCheckbox = reg.byId('preference-override');
         $(titleArea).find('h1').text(node.name);
         if (preferenceManager.getParentStore(store)) {
-            overrideCheckbox.set('checked', store.status.override);
-            __dim(store.status.override);
             $('.preference-override-box').removeClass('hidden');
+            overrideCheckbox.set('checked', store.status.override, false);
+            __dim(store.status.override);
         } else {
             $('.preference-override-box').addClass('hidden');
         }
@@ -163,8 +164,7 @@ define([
                     }
                 });
             }),
-            on(overrideCheckbox, 'change', function () {
-                var checked = overrideCheckbox.get('checked');
+            on(overrideCheckbox, 'change', function (checked) {
                 currentPage.store.setOverride(checked);
                 __dim(checked);
             })

--- a/common/src/webida/plugins/git/plugin.json
+++ b/common/src/webida/plugins/git/plugin.json
@@ -117,8 +117,7 @@
                 "getDefault": "getDefault",
                 "page": "SimplePage",
                 "pageData": "getSchema",
-                "scope": ["WORKSPACE"],
-                "visible": "false"
+                "scope": []
             }
         ],
         


### PR DESCRIPTION
- If parent is not exist in the same scope, child nodes will be shown below the closest exist ancestor node.
- `visible` property of the `webida.preference:pages` extension can be replaced with empty scope array `scope: []`
- improve validation messaging
- cannot change selection of tree item until sub-page is loaded completely