### PR TITLE
[BUGFIX](#432) The action of 'Editor Tab Split' runs contrary

### DIFF
--- a/common/src/webida/plugins/editors/menu-items.js
+++ b/common/src/webida/plugins/editors/menu-items.js
@@ -83,8 +83,8 @@ define([], function () {
 
     var viewMenuItems = {
         'Spl&it Editors' : {
-            '&Vertical' : [ 'cmnd', 'webida-lib/plugins/editors/editors-commands', 'rotateToVertical' ],
-            '&Horizontal' : [ 'cmnd', 'webida-lib/plugins/editors/editors-commands', 'rotateToHorizontal' ],
+            '&Vertical' : [ 'cmnd', 'webida-lib/plugins/editors/editors-commands', 'rotateToHorizontal' ],
+            '&Horizontal' : [ 'cmnd', 'webida-lib/plugins/editors/editors-commands', 'rotateToVertical' ],
         }
     };
 


### PR DESCRIPTION
[DESC.] Split view behavior is changed.