### PR TITLE
[BUGFIX](#517)FInd/replace dialogs are closed immediately after opening.

### DIFF
--- a/apps/ide/src/plugins/webida.editor.code-editor/CodeEditorViewer.js
+++ b/apps/ide/src/plugins/webida.editor.code-editor/CodeEditorViewer.js
@@ -1335,7 +1335,6 @@ define([
         rename: function () {
             this.addDeferredAction(function (self) {
                 var editor = self.editor;
-                self.focus();
 
                 // rename trigger
                 editor.execCommand('tern-rename');

--- a/apps/ide/src/plugins/webida.editor.text-editor/TextEditorViewer.js
+++ b/apps/ide/src/plugins/webida.editor.text-editor/TextEditorViewer.js
@@ -1318,18 +1318,15 @@ define([
 
         replace: function() {
             this.addDeferredAction(function(self) {
-                var editor = self.editor;
-                self.focus();
+                var editor = self.editor;                
                 editor.execCommand('replace');
             });
         },
 
         find: function() {
             this.addDeferredAction(function(self) {
-                var editor = self.editor;
-                self.focus();
+                var editor = self.editor;                
                 editor.execCommand('find');
-
             });
         },
 


### PR DESCRIPTION
[DESC.] Related to viewer.focus()