### PR TITLE
[BUGFIX](#261) Cursor does not move to the right line when a result of '…

### DIFF
--- a/common/src/webida/plugins/output/plugin.js
+++ b/common/src/webida/plugins/output/plugin.js
@@ -74,7 +74,12 @@ define([
 
                 var elm = $('<span>').addClass('fileloc_link pre_whitespace').text(text);
                 elm.on('click', function () {
-                    topic.publish('editor/open', path, { pos: pos });
+                    topic.publish('editor/open', path, {}, function (part) {
+                        var viewer = part.getViewer();
+                        if (typeof viewer.setCursor === 'function') {
+                            viewer.setCursor(pos);
+                        }
+                    });
                     elm.addClass('fileloc_link_clicked');
                 });
 


### PR DESCRIPTION
Cursor does not move to the right line when a result of 'Find in Files' is clicked.

Signed-off-by: Minsung Jin <minsung.jin@samsung.com>