### PR TITLE
[BUGFIX] Make 'prop' to be a local variable.

### DIFF
--- a/common/src/webida/util/genetic.js
+++ b/common/src/webida/util/genetic.js
@@ -47,7 +47,7 @@ define(function() {
             var target = {};
             for (var i = 0; i < arguments.length; i++) {
                 source = arguments[i];
-                for (prop in source) {
+                for (var prop in source) {
                     target[prop] = source[prop];
                 }
             }


### PR DESCRIPTION
Without explicit 'var' keyword, prop will be a global variable.