### PR TITLE
[BUGFIX] A root directory is not refresh in a workspace.

### DIFF
--- a/common/src/webida/FSCache-0.1.js
+++ b/common/src/webida/FSCache-0.1.js
@@ -1569,6 +1569,7 @@ function (webida, SortedArray, pathUtil, _, URI, declare, topic) {
                 }
                 path = pathParsed.path;
             }
+            path += '/';
             return dirsToCache.some(function (cached) { return path.indexOf(cached) === 0; });
         }
         function getName(obj) { return obj.name; }

--- a/common/src/webida/FSCache-0.1.js
+++ b/common/src/webida/FSCache-0.1.js
@@ -665,7 +665,7 @@ function (webida, SortedArray, pathUtil, _, URI, declare, topic) {
                 path = target.split(/[\\/]/);
                 path.pop();
 				if (path.length === 1) {
-					dir = '/'
+					dir = '/';
 				} else {
 	                dir = path.join('/');
 				}


### PR DESCRIPTION
 - If the workspace is refreshed after creating a file or a directory using a terminal, the file or the directory isnot shown.
 - fix it inserting a delimiter in dir cache.

Signed-off-by: Minsung Jin <minsung.jin@samsung.com>