### PR TITLE
[TASK] Use updated calcium, whose aux.js is renamed to helper.js.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
         "socket.io-client": "git://github.com/automattic/socket.io-client#~1.3.5",
         "eventEmitter": "~4.2.11",
         "bootstrap-treeview": "~1.2.0",
-        "calcium": "git://github.com/webida/calcium#f2fe931899f4d719879683cb5d5d8201508292b5",
+        "calcium": "git://github.com/webida/calcium#b5a88d862d1e4afb7793d3affc6ca84a43bb48fe",
         "smalot-bootstrap-datetimepicker": "~2.3.4"
     } 
 }


### PR DESCRIPTION
Note that file named as 'aux.js' is not allowed on windows.