### PR TITLE
[BUGFIX] A root directory is not refresh in a workspace.

### DIFF
--- a/common/src/webida/FSCache-0.1.js
+++ b/common/src/webida/FSCache-0.1.js
@@ -1565,7 +1565,6 @@ function (webida, SortedArray, pathUtil, _, URI, declare, topic) {
                 }
                 path = pathParsed.path;
             }
-            path += '/';
             return dirsToCache.some(function (cached) { return path.indexOf(cached) === 0; });
         }
         function getName(obj) { return obj.name; }

--- a/common/src/webida/plugins/workspace/plugin.js
+++ b/common/src/webida/plugins/workspace/plugin.js
@@ -757,7 +757,7 @@ define([
 
             if (item.toRefresh) {
                 item.toRefresh = false;
-                fsCache.refreshHierarchy(item.id, {
+                fsCache.refreshHierarchy(item.getPath(), {
                     level: 1
                 }, expandNode);
             } else {


### PR DESCRIPTION
- If the workspace is refreshed after creating a file or a directory using a terminal, the file or the directory isnot shown.

Signed-off-by: Minsung Jin <minsung.jin@samsung.com>