### PR TITLE
[BUGFIX] Datasource not unregist when directory or file deleted

### DIFF
--- a/common/src/webida/plugins/workbench/ui/partModelProvider.js
+++ b/common/src/webida/plugins/workbench/ui/partModelProvider.js
@@ -32,7 +32,7 @@ define([
     './PartRegistry'
 ], function(
     workbench,
-    genetic, 
+    genetic,
     Logger,
     PartModel,
     PartRegistry
@@ -207,9 +207,7 @@ define([
                 var model = part.getModel();
                 if (provider.isModelProvided(model) === true
                         && provider.isDataSourceUsed(dataSource) === false) {
-                    if (dataSource.isDeleted()) {
-                        dsReg.unregister(dataSource);
-                    }
+                    dsReg.unregister(dataSource);
                     provider.unregisterModels(dataSource);
                 }
             });


### PR DESCRIPTION
- If dataSource is not used, then dataSource must unregistration.

Signed-off-by: GyeongSeok Seo <gyseok.seo@samsung.com>
Change-Id: Ief2c4c5f489edb68df222cdf4477b4fe142ed159