### PR TITLE
[BUGFIX] Datasource not unregist when directory or file deleted

### DIFF
--- a/common/src/webida/plugins/workbench/ui/partModelProvider.js
+++ b/common/src/webida/plugins/workbench/ui/partModelProvider.js
@@ -32,7 +32,7 @@ define([
     './PartRegistry'
 ], function(
     workbench,
-    genetic, 
+    genetic,
     Logger,
     PartModel,
     PartRegistry
@@ -207,9 +207,7 @@ define([
                 var model = part.getModel();
                 if (provider.isModelProvided(model) === true
                         && provider.isDataSourceUsed(dataSource) === false) {
-                    if (dataSource.isDeleted()) {
-                        dsReg.unregister(dataSource);
-                    }
+                    dsReg.unregister(dataSource);
                     provider.unregisterModels(dataSource);
                 }
             });


### PR DESCRIPTION
- If dataSource is not used, then dataSource must be unregistered

Change-Id: I91e4e19ecf62e03e1395bb27a8e5b8d2bc69c239
Signed-off-by: GyeongSeok Seo <gyseok.seo@samsung.com>