### PR TITLE
[BUGFIX] fix "Nanum Gothic Coding" font can not apply

### DIFF
--- a/apps/ide/src/styles/css/webida-base.css
+++ b/apps/ide/src/styles/css/webida-base.css
@@ -1,3 +1,14 @@
+@font-face {
+    font-family: "Nanum Gothic Coding";
+    src: url('//fonts.gstatic.com/ea/nanumgothiccoding/v4/NanumGothicCoding-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+.body{
+   font-family: "Nanum Gothic Coding", Verdana,Arial,sans-serif;
+}
+
 /*theme*/
 /*GNB*/
 /*toolbar*/


### PR DESCRIPTION
[DESC.] declear for font-family in css

please don't make regression bug.
It was modified in the past, but it was returned.
* https://github.com/webida/webida-client/commit/a68bb73debd6073db45b7e820c2f6aabefb8b1f0

Signed-off-by: ChangHyun Lee <leechwin.lee@samsung.com>