### PR TITLE
[BUGFIX] fix a bug that cannot get a service instance scoped as project

### DIFF
--- a/apps/ide/src/plugins/webida.preference/preference-service-factory.js
+++ b/apps/ide/src/plugins/webida.preference/preference-service-factory.js
@@ -120,6 +120,9 @@ define([
                 instances[scopeName] = new PreferenceService(scopeName);
                 return instances[scopeName];
             case 'PROJECT':
+                if (!instances[scopeName]) {
+                    instances[scopeName] = {};
+                }
                 instances[scopeName][additionalInfo] = new ProjectPreferenceService(scopeName, additionalInfo);
                 return instances[scopeName][additionalInfo];
         }

--- a/apps/ide/src/plugins/webida.preference/services/preference-service.js
+++ b/apps/ide/src/plugins/webida.preference/services/preference-service.js
@@ -133,8 +133,8 @@ define([
         return result && result[key];
     };
 
-    /* global self */
     PreferenceService.prototype.setValues = function (preferenceId, values, callback) {
+        var self = this;
         var store = preferenceManager.getStore(preferenceId, self.scope);
         if (values) {
             for (var key in values) {
@@ -158,6 +158,7 @@ define([
     };
 
     PreferenceService.prototype.setValue = function (preferenceId, key, value, callback) {
+        var self = this;
         var store = preferenceManager.getStore(preferenceId, self.scope);
         store.setValue(key, value);
         store.apply(function (invalid) {

--- a/apps/ide/src/plugins/webida.preference/services/project-preference-service.js
+++ b/apps/ide/src/plugins/webida.preference/services/project-preference-service.js
@@ -35,14 +35,14 @@ define([
 ) {
     'use strict';
     function ProjectPreferenceService(scopeName, projectName) {
-        PreferenceService.apply(this, scopeName);
+        PreferenceService.apply(this, [scopeName]);
         this.projectName = projectName;
     }
 
     genetic.inherits(ProjectPreferenceService, PreferenceService, {
         getValues: function (preferenceId, callback) {
             var self = this;
-            preferenceManager.initialized.then(function () {
+            preferenceManager.initialize().then(function () {
                 if (callback) {
                     callback(self._getRealPreferenceValues(preferenceManager.getStore(preferenceId, self.scope, {
                         projectName: self.projectName


### PR DESCRIPTION
An error occurred while getting a service instance scoped as a project because there is no
project scope. So modify code to create a project scope before creating instance of a service.

In addition, it modifies the instance creation part of the service.
Change a second parameter of .apply as an array. It is because must be an array.
And instead of referring to non-existent 'initialized' property to correct to call a 'initialize' function.

And also change the reference to the global self with reference to the local self.
It is because there is no global self.

Signed-off-by: Jugwan Kim <jugwan@webida.org>