### PR TITLE
[BUGFIX] solve unexpected rendered tree hierarchies in preference dialog

### DIFF
--- a/apps/ide/src/plugins/webida.editor.code-editor/plugin.json
+++ b/apps/ide/src/plugins/webida.editor.code-editor/plugin.json
@@ -30,7 +30,7 @@
             {
                 "module": "plugins/webida.editor.code-editor/preferences/preference-main",
                 "id": "codeeditor",
-                "hierarchy": "texteditor",
+                "hierarchy": "editor",
                 "name": "Code Editor",
                 "getDefault": "getDefault",
                 "page": "SimplePage",
@@ -40,7 +40,7 @@
             {
                 "module": "plugins/webida.editor.code-editor/preferences/preference-contentassist",
                 "id": "content-assist",
-                "hierarchy": "texteditor/codeeditor",
+                "hierarchy": "editor/codeeditor",
                 "name": "Content Assists",
                 "getDefault": "getDefault",
                 "page": "SimplePage",

--- a/apps/ide/src/plugins/webida.editor.text-editor/plugin.json
+++ b/apps/ide/src/plugins/webida.editor.text-editor/plugin.json
@@ -19,7 +19,7 @@
         "webida.preference:pages" : [
             {
                 "module": "plugins/webida.editor.text-editor/preferences/preference-appearance",
-                "id": "texteditor",
+                "id": "editor",
                 "hierarchy": "",
                 "name": "Editor",
                 "page": "SimplePage",
@@ -30,7 +30,7 @@
             {
                 "module": "plugins/webida.editor.text-editor/preferences/preference-editor",
                 "id": "texteditor.lines",
-                "hierarchy": "texteditor",
+                "hierarchy": "editor",
                 "name": "Lines",
                 "page": "SimplePage",
                 "pageData": "getSchema",
@@ -40,7 +40,7 @@
             {
                 "module": "plugins/webida.editor.text-editor/preferences/preference-keys",
                 "id": "texteditor.key-map",
-                "hierarchy": "texteditor",
+                "hierarchy": "editor",
                 "name": "Key Map",
                 "page": "SimplePage",
                 "pageData": "getSchema",
@@ -50,7 +50,7 @@
             {
                 "module": "plugins/webida.editor.text-editor/preferences/preference-show",
                 "id": "texteditor.show-hide",
-                "hierarchy": "texteditor",
+                "hierarchy": "editor",
                 "name": "Show or Hide",
                 "page": "SimplePage",
                 "pageData": "getSchema",

--- a/apps/ide/src/plugins/webida.preference/preference-manager.js
+++ b/apps/ide/src/plugins/webida.preference/preference-manager.js
@@ -96,7 +96,9 @@ define([
         var self = this;
         this.SCOPE = SCOPE;
         this.preferences = [];
-        this.extensions = pluginManager.getExtensions(EXTENSION_NAME);
+        this.extensions = _.sortBy(pluginManager.getExtensions(EXTENSION_NAME), function (item) {
+            return (item.hierarchy ? (item.hierarchy + '/') : '') + item.id;
+        });
         this.extensionsByScope = {};
 
         function _getAllPreferenceFiles() {


### PR DESCRIPTION
[DESC.]
- For drawing tree nicely, the pages in preferences should be sorted by its hierarchy.
- change page id to its displayed name ('texteditor' -> 'editor') for sorting