### PR TITLE
[BUGFIX] set `alternateLabel` property in `convertMenuItem` method with no enumerable option

### DIFF
--- a/common/src/webida/util/locale.js
+++ b/common/src/webida/util/locale.js
@@ -116,7 +116,12 @@ define([
         postfix = postfix || '';
         for (item in menuItems) {
             if (menuItems.hasOwnProperty(item)) {
-                menuItems[item].alternateLabel = this.resources[prefix + item + postfix];
+                Object.defineProperty(menuItems[item], 'alternateLabel', {
+                    value: this.resources[prefix + item + postfix],
+                    writable: true,
+                    configurable: true,
+                    enumerable: false
+                });
             }
         }
         return menuItems;


### PR DESCRIPTION
[DESC.]
- If it runs with enumerable option, top-down converting on menu items that has hierarchy may occurres an error.