### PR TITLE
[TASK] Use codemirror updated to 5.8.0.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
         "bower_components"
     ],
     "dependencies": {
-        "codemirror": "webida/codemirror#f0fb78a6eedb9550c875714154847208a7a5edc1",
+        "codemirror": "webida/codemirror#f23a4a96fdc2b4102abe3018ae12d4b5e0e9a122",
         "dgrid": "0.3.11",
         "put-selector": "~0.3.6",
         "xstyle": "~0.3.1",


### PR DESCRIPTION
[DESC.]
This commit allows us to use the updated codemirror through bower.
* This version has a new option "lineSeparator" which makes #707 by @hwshim work properly.
* The problem of webida/codemirror#64 does not occur.
* It has a minor problem of overlapping hints ( webida/codemirror#66 ), which will be fixed soon.