### PR TITLE
[BUGFIX](#705)File download does not work when editor have a dirty file

### DIFF
--- a/common/src/webida/webida-0.3.js
+++ b/common/src/webida/webida-0.3.js
@@ -1144,7 +1144,7 @@ var ENV_TYPE;
         var url = mod.conf.fsApiBaseUrl + '/archive/' + this.fsid + argument;
 
         function restApi() {
-            location.href = url + '&access_token=' + token.data;
+            window.open(url + '&access_token=' + token.data);
         }
 
         ensureAuthorize(restApi);


### PR DESCRIPTION
[DESC.] File download does not work when editor have a dirty file. That is caused by using location.href for download. We changed location.href using to using window.open().