### PR TITLE
[BUGFIX] (#749, #755) Missing preference problem for TextEditor 

### DIFF
--- a/apps/ide/src/plugins/webida.editor.text-editor/preferences/preference-editor.js
+++ b/apps/ide/src/plugins/webida.editor.text-editor/preferences/preference-editor.js
@@ -31,7 +31,8 @@ define([
                 'webida.editor.text-editor:tabsize': 4,
                 'webida.editor.text-editor:indentunit': 4,
                 'webida.editor.text-editor:indentWithTabs': false,
-                'webida.editor.text-editor:indentOnPaste': true
+                'webida.editor.text-editor:indentOnPaste': true,
+                'webida.editor.text-editor:highlightselection': true
             };
         },
         getSchema: function () {

--- a/apps/ide/src/plugins/webida.editor.text-editor/preferences/preference-editor.js
+++ b/apps/ide/src/plugins/webida.editor.text-editor/preferences/preference-editor.js
@@ -32,7 +32,8 @@ define([
                 'webida.editor.text-editor:indentunit': 4,
                 'webida.editor.text-editor:indentWithTabs': false,
                 'webida.editor.text-editor:indentOnPaste': true,
-                'webida.editor.text-editor:highlightselection': true
+                'webida.editor.text-editor:highlightselection': true,
+                'webida.editor.text-editor:activeline': true
             };
         },
         getSchema: function () {


### PR DESCRIPTION
* Missing underlines for same words when double-clicked (#749)
* Missing active line styling (#755) 