### PR TITLE
[IMPROVEMENT] Specify topics related with file

### DIFF
--- a/common/src/webida/app.js
+++ b/common/src/webida/app.js
@@ -399,23 +399,38 @@ define(['webida-lib/util/browserInfo',
                     var callbacks = {
                         usermsg: null,
                         topicsysnotify: function (_, data) {
-
                             // TODO: move the following getWFSURL to the webida-x.js.
                             function getWFSURL(fsServer, fsid, path) {
                                 return 'wfs://' + fsServer + '/' + fsid + path;
                             }
 
                             switch (data.eventType) {
-                            case 'file.written':
-                                topic.publish('remote/persistence/written', {
+                            case 'file.created':
+                                topic.publish('remote/persistence/created', {
                                     uid: data.opUid,
                                     sid: data.sessionID,
                                     url: getWFSURL(new URI(webida.conf.fsServer).host(),
-                                                   data.fsId, data.path)
+                                        data.fsId, data.path)
+                                });
+                                break;
+                            case 'file.updated':
+                                topic.publish('remote/persistence/updated', {
+                                    uid: data.opUid,
+                                    sid: data.sessionID,
+                                    url: getWFSURL(new URI(webida.conf.fsServer).host(),
+                                        data.fsId, data.path)
                                 });
                                 break;
                             case 'file.deleted':
                                 topic.publish('remote/persistence/deleted', {
+                                    uid: data.opUid,
+                                    sid: data.sessionID,
+                                    url: getWFSURL(new URI(webida.conf.fsServer).host(),
+                                        data.fsId, data.path)
+                                });
+                                break;
+                            case 'file.written':
+                                topic.publish('remote/persistence/written', {
                                     uid: data.opUid,
                                     sid: data.sessionID,
                                     url: getWFSURL(new URI(webida.conf.fsServer).host(),


### PR DESCRIPTION
[DESC.]
- add handler for 'file.created' and 'file.updated' notifications from server
- and new topics, 'remote/persistence/created' and 'remote/persistence/updated', became to be used by client.

Related with https://github.com/kyungmi/webida-server/commit/27a4aca14e82211ae2db1da20fa01edeb3dfeaed