### PR TITLE
[FEATURE] #760 modify Gruntfile.js for building on less files and related resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,17 @@
     "devDependencies": {
         "grunt": "~0.4.2",
         "grunt-bower-task": "^0.4.0",
-        "grunt-contrib-copy": "~0.5.0",
-        "grunt-contrib-uglify": "~0.4.0",
-        "grunt-contrib-cssmin": "~0.9.0",
-        "grunt-contrib-clean": "~0.5.0",
-        "grunt-contrib-jshint": "^0.10.0",
-        "grunt-exec": "~0.4.5",
-        "grunt-dom-munger": "~3.4.0",
-        "jshint-stylish": "^1.0.0",
         "grunt-contrib-clean": "~0.4.0",
-        "grunt-prettify": "~0.3.4"
+        "grunt-contrib-copy": "~0.5.0",
+        "grunt-contrib-cssmin": "~0.9.0",
+        "grunt-contrib-jshint": "^0.10.0",
+        "grunt-contrib-less": "^1.1.0",
+        "grunt-contrib-uglify": "~0.4.0",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-dom-munger": "~3.4.0",
+        "grunt-exec": "~0.4.5",
+        "grunt-prettify": "~0.3.4",
+        "jshint-stylish": "^1.0.0"
     },
     "scripts": {
         "prepublish": "echo 'prepublish'; if [ -z $RELEASE_BUILD ]; then grunt; else grunt release; fi"


### PR DESCRIPTION
[FEATURE] #760 modify Gruntfile.js for building on less files and related resources

[DESC.]
- add new grunt task 'themeBuild' that generate and run tasks related with theme resourcees automatically
    - With `grunt themeBuild`(build all), `grunt themeBuild:less`(build less file only), `grunt themeBuild:resource`(build(copy) resources only), you can build theme.
- add new grunt task 'watch' for theme development
    - Run this task with the `grunt watch` command