### PR TITLE
[FEATURE] #760 load dynamically proper theme.css file

### DIFF
--- a/apps/ide/src/index.html
+++ b/apps/ide/src/index.html
@@ -8,9 +8,6 @@
         <link rel="stylesheet" href="styles/common/dijit.css" type="text/css" class="source"/>
         <link rel="stylesheet" href="styles/common/toastr.min.css" type="text/css" class="source"/>
 
-        <link rel="stylesheet" href="styles/dist/webida-light/css/theme.css" type="text/css" class="source"/>
-        <link rel="shorcut icon" href="styles/dist/webida-light/images/icons/webida_favicon_16.png" type="image/x-icon">
-
         <title>IDE</title>
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
         <script src="./dojoConfig.js" class="source"></script>
@@ -19,10 +16,17 @@
         <script>
             'use strict';
 
-            require(['webida-lib/util/load-polyfills', 'webida-lib/app-config', 'webida-lib/app'], function (loader, AppConfig, ide) {
-                loader.load(function (){
-                    ide.startup(AppConfig.clientId, AppConfig.redirectUrl);
-                });
+            require([
+                'webida-lib/app',
+                'webida-lib/theme',
+                'webida-lib/util/load-polyfills'
+            ], function (
+                ide,
+                theme,
+                loader
+            ) {
+                theme.loadTheme();
+                loader.load(ide.startup);
             });
         </script>
         <script>

--- a/common/src/webida/app-config.js
+++ b/common/src/webida/app-config.js
@@ -15,11 +15,11 @@
  */
 
 define([
-    'webida-lib/webida-0.3',
-    'webida-lib/util/logger/logger-client'
+    'webida-lib/util/logger/logger-client',
+    'webida-lib/webida-0.3'
 ], function (
-    webida,
-    Logger
+    Logger,
+    webida
 ) {
     'use strict';
     var logger = new Logger();

--- a/common/src/webida/app.js
+++ b/common/src/webida/app.js
@@ -15,35 +15,37 @@
  */
 
 define([
-    'dojo/topic',
-    'dojo/_base/lang',
     'external/lodash/lodash.min',
     'external/URIjs/src/URI',
-    'webida-lib/util/browserInfo',
-    'webida-lib/util/loading-screen',
-    'webida-lib/util/notify',
-    'webida-lib/webida-0.3',
+    'dojo/_base/lang',
+    'dojo/topic',
+    'webida-lib/app-config',
+    'webida-lib/FSCache-0.1',
     'webida-lib/msg',
     'webida-lib/plugin-manager-0.1',
-    'webida-lib/FSCache-0.1',
-    'webida-lib/widgets/dialogs/popup-dialog/PopupDialog',
+    'webida-lib/util/browserInfo',
+    'webida-lib/util/loading-screen',
     'webida-lib/util/logger/logger-client',
-    'webida-lib/util/timedLogger',
+    'webida-lib/util/notify',
+    'webida-lib/webida-0.3',
+    'webida-lib/widgets/dialogs/popup-dialog/PopupDialog',
+    'webida-lib/util/timedLogger',  // not used locally
     'dojo/domReady!'
 ], function (
-    topic,
-    lang,
     _,
     URI,
-    brInfo,
-    loadingScreen,
-    notify,
-    webida,
+    lang,
+    topic,
+    appConfig,
+    FSCache,
     msgAgent,
     pm,
-    FSCache,
-    PopupDialog,
-    Logger
+    brInfo,
+    loadingScreen,
+    Logger,
+    notify,
+    webida,
+    PopupDialog
 ) {
     'use strict';
 
@@ -196,7 +198,7 @@ define([
      * @callback open_workspace
      * @returns {undefined}
      */
-    function startup(clientID, redirectUrl, options) {
+    function startup(options) {
         singleLogger.log('%c*** Starting Open Development Platform ***', 'color:green');
         function proceed() {
             var currentURI = URI(window.location.href);
@@ -212,7 +214,7 @@ define([
                 });
             } else {
                 var appPathname = currentURI.segment(-1, '').pathname();
-                webida.auth.initAuth(clientID, redirectUrl, null, function () {
+                webida.auth.initAuth(appConfig.clientId, appConfig.redirectUrl, null, function () {
                     init(appPathname, workspaceInfo, options);
                 });
             }

--- a/common/src/webida/theme.js
+++ b/common/src/webida/theme.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2015 S-Core Co., Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,9 +15,9 @@
  */
 
 /**
- *
- * @since: 15. 11. 24
- * @author: Koong Kyungmi (kyungmi.k@samsung.com)
+ * @file Provides some light-weight theme related tools(It may be used before introducing theme system.)
+ * @since 15. 11. 24
+ * @author Koong Kyungmi (kyungmi.k@samsung.com)
  */
 
 define([
@@ -30,9 +30,47 @@ define([
     'use strict';
     var theme = config.theme;
 
+    function _createLinkElement(href, rel, type) {
+        var linkElement = document.createElement('link');
+        linkElement.href = href;
+        linkElement.rel = rel || 'stylesheet';
+        linkElement.type = type || 'text/css';
+        document.getElementsByTagName('head')[0].appendChild(linkElement);
+    }
+
     return {
+        /**
+         * @public
+         * Apply theme to template string that has placeholders
+         *
+         * @exmaple
+         * <pre>
+         *      require(['webida-lib/theme'], function(theme) {
+         *          ...
+         *          var themeAppliedTemplate = theme.apply('<img src="<%=themePath%>/images/logo.png">');
+         *          // '<img src="/apps/ide/src/styles/theme/webida-light/images/logo.png">'
+         *          var themeAppliedImageUrl = theme.apply('<%=themePath%>/images/icon/someIcon.png');
+         *          // '/apps/ide/src/styles/theme/webida-light/images/icon/someIcon.png'
+         *          var themeName = theme.apply('<%=theme%> is applied!');
+         *          // 'webida-light is applied!'
+         *          ...
+         *      });
+         * </pre>
+         *
+         * @param {string} template - template string that has theme related placeholders
+         * @return the variables(<%= theme %> or <%= themePath %>) related with theme applied string
+         */
         apply: function (template) {
             return _.template(template)({theme: theme.name, themePath: theme.basePath});
+        },
+
+        /**
+         * @public
+         * Loads all theme related resources
+         */
+        loadTheme: function () {
+            _createLinkElement(theme.basePath + '/css/theme.css');
+            _createLinkElement(theme.basePath + '/images/icons/webida_favicon_16.png', 'shorcut icon', 'image/x-icon');
         }
     };
 });


### PR DESCRIPTION
#760 

[DESC.]
- check current theme(set in app-config) and load proper css and favicon file
- Simplify `ide.startup` method
- following code conventions