### PR TITLE
[IMPROVEMENT] #754 Synchronous XMLHttpRequest on the main thread is deprecated (jQuery)

### DIFF
--- a/common/src/webida/app-config.js
+++ b/common/src/webida/app-config.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2015 S-Core Co., Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,29 +15,12 @@
  */
 
 define([
-    'webida-lib/util/logger/logger-client',
-    'webida-lib/webida-0.3'
+    'webida-lib/config-loader!'
 ], function (
-    Logger,
-    webida
+    serverConf
 ) {
     'use strict';
-    var logger = new Logger();
     var APP_ID = 'webida-client';
-    var serverConf;
-
-    try {
-        serverConf = JSON.parse($.ajax({
-            type: 'GET',
-            url: webida.conf.appApiBaseUrl + '/configs',
-            async: false
-        }).responseText);
-    } catch (e) {
-        logger.warn('Failed to load configs. Using default one: ' + e.message);
-        serverConf = {
-            systemApps: { 'webida-client': { baseUrl: window.location.protocol + '//' + window.location.host } }
-        };
-    }
 
     return {
         appId: APP_ID,

--- a/common/src/webida/config-loader.js
+++ b/common/src/webida/config-loader.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2015 S-Core Co., Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file Get server-side configuration in advance of bootstrapping the app
+ *
+ * This is a kind of loader plugin of Require.js.
+ *
+ * @since 15. 12. 3
+ * @author Koong Kyungmi (kyungmi.k@samsung.com)
+ */
+
+define([
+    'webida-lib/webida-0.3'
+], function (
+    webida
+) {
+    'use strict';
+
+    return {
+        load: function (name, req, onLoad) {
+            req([webida.conf.appApiBaseUrl + '/configs?callback=define'], function (configs) {
+                onLoad(configs);
+            });
+        }
+    };
+});


### PR DESCRIPTION
#754 

[DESC.]
- In jquery, synchronous ajax query was deprecated because of its bad effects to UX.
- So our Synchronous XMLHttpRequest in `app-config` is replaced with "loader plugin of Require.js" for loading server-side configs.
- It is more clear way to get configurations than before.
- This new `config-loader` loader plugin enables that `app-config` module can return value asynchronously.