### PR TITLE
Issue#375 improvements, documentation and bugfix on run configuration plugin

### DIFF
--- a/apps/ide/src/plugins/webida.ide.project-management.run.java/layout/java-run-configuration.html
+++ b/apps/ide/src/plugins/webida.ide.project-management.run.java/layout/java-run-configuration.html
@@ -1,13 +1,13 @@
 <span class="asterisk">*</span> <span data-message="labelAsteriskExplain">indicates required field</span>
 <div class="run-configuration-detail">
-    <div class="rcw-content">
+    <form id="run-configuration-java-form" class="rcw-content">
         <div class="rcw-table">
             <div class="rcw-table-row row-Path">
                 <div class="rcw-content-table-label rcw-table-col">
-                    <label for="run-configuration-java-Name" data-message="labelName">Name</label> <span class="asterisk">*</span>
+                    <label for="run-configuration-java-name" data-message="labelName">Name</label> <span class="asterisk">*</span>
                 </div>
                 <div class="rcw-content-table-value rcw-table-col">
-                    <input id="run-configuration-java-Name" style="width:303px" class="rcw-content-table-inputbox-edit"/>
+                    <input id="run-configuration-java-name" class="rcw-content-table-inputbox-edit"/>
                 </div>
             </div>
             <div class="rcw-table-row">
@@ -25,7 +25,7 @@
                     <span class="asterisk">*</span>
                 </div>
                 <div class="rcw-content-table-value rcw-table-col">
-                    <input id="run-configuration-java-path" style="width:234px" class="rcw-content-table-inputbox-readonly" />
+                    <input id="run-configuration-java-path" class="rcw-content-table-inputbox-readonly" />
                     <div class="rcw-action-path" title="Select a path"></div>
                 </div>
             </div>
@@ -35,5 +35,5 @@
             <!--<div class="rcw-action-save" title="Save run configuration"></div>-->
             <button data-dojo-type="dijit/form/Button" type="button" id="rcw-action-save" data-message="labelApply">Apply</button>
         </div>
-    </div>
+    </form>
 </div>

--- a/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/en-us/resource.js
+++ b/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/en-us/resource.js
@@ -5,6 +5,7 @@ define({
     labelPath: 'Path',
     labelProject: 'Project',
     messageFailFindRoot: 'Cannot find root path',
+    messageFailGetProjects: 'failed to get project list',
     titleSelectMain: 'Select the Main Java File to Run',
     validationInvalidForm: 'Form contains invalid data. Please correct first.',
     validationInvalidPath: 'Invalid selected path',

--- a/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/en-us/resource.js
+++ b/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/en-us/resource.js
@@ -1,13 +1,15 @@
 define({
-    validationInvalidPath: 'Invalid selected path',
-    validationNoName: 'Enter a name.',
-    validationNoPath: 'Select a path.',
-    messageFailFindRoot: 'Cannot find root path',
-    titleSelectMain: 'Select the Main Java File to Run',
-    validationNoJavaFile: 'Select a java file.',
+    labelApply: 'Apply',
     labelAsteriskExplain: 'indicates required field',
     labelName: 'Name',
-    labelProject: 'Project',
     labelPath: 'Path',
-    labelApply: 'Apply'
+    labelProject: 'Project',
+    messageFailFindRoot: 'Cannot find root path',
+    titleSelectMain: 'Select the Main Java File to Run',
+    validationInvalidForm: 'Form contains invalid data. Please correct first.',
+    validationInvalidPath: 'Invalid selected path',
+    validationNoJavaFile: 'Select a java file.',
+    validationNoName: 'Enter a name.',
+    validationNoPath: 'Select a path.',
+    validationNoProject: 'You should fill the target project',
 });

--- a/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/resource.js
+++ b/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/resource.js
@@ -1,16 +1,18 @@
 define({
     root: {
-        validationInvalidPath: 'Invalid selected path',
-        validationNoName: 'Enter a name.',
-        validationNoPath: 'Select a path.',
-        messageFailFindRoot: 'Cannot find root path',
-        titleSelectMain: 'Select the Main Java File to Run',
-        validationNoJavaFile: 'Select a java file.',
+        labelApply: 'Apply',
         labelAsteriskExplain: 'indicates required field',
         labelName: 'Name',
-        labelProject: 'Project',
         labelPath: 'Path',
-        labelApply: 'Apply'
+        labelProject: 'Project',
+        messageFailFindRoot: 'Cannot find root path',
+        titleSelectMain: 'Select the Main Java File to Run',
+        validationInvalidForm: 'Form contains invalid data. Please correct first.',
+        validationInvalidPath: 'Invalid selected path',
+        validationNoJavaFile: 'Select a java file.',
+        validationNoName: 'Enter a name.',
+        validationNoPath: 'Select a path.',
+        validationNoProject: 'You should fill the target project'
     },
     'en-us': true
 });

--- a/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/resource.js
+++ b/apps/ide/src/plugins/webida.ide.project-management.run.java/nls/resource.js
@@ -6,6 +6,7 @@ define({
         labelPath: 'Path',
         labelProject: 'Project',
         messageFailFindRoot: 'Cannot find root path',
+        messageFailGetProjects: 'failed to get project list',
         titleSelectMain: 'Select the Main Java File to Run',
         validationInvalidForm: 'Form contains invalid data. Please correct first.',
         validationInvalidPath: 'Invalid selected path',

--- a/apps/ide/src/plugins/webida.ide.project-management.run.java/plugin.js
+++ b/apps/ide/src/plugins/webida.ide.project-management.run.java/plugin.js
@@ -16,7 +16,10 @@
 
 define([
     'external/lodash/lodash.min',
+    'dijit/form/Form',
     'dijit/form/Select',
+    'dijit/form/TextBox',
+    'dijit/form/ValidationTextBox',
     'dijit/layout/ContentPane',
     'dijit/registry',
     'dojo/i18n!./nls/resource',
@@ -24,12 +27,16 @@ define([
     'dojo/topic',
     'webida-lib/app',
     'webida-lib/util/locale',
+    'webida-lib/util/logger/logger-client',
     'webida-lib/util/notify',
     'webida-lib/widgets/dialogs/file-selection/FileSelDlg2States', // FileDialog
     'text!./layout/java-run-configuration.html'
 ], function (
     _,
+    Form,
     Select,
+    TextBox,
+    ValidationTextBox,
     ContentPane,
     registry,
     i18n,
@@ -37,63 +44,52 @@ define([
     topic,
     ide,
     Locale,
+    Logger,
     notify,
     FileDialog,
     template
 ) {
     'use strict';
 
+    var logger = new Logger();
+    logger.off();
+
     var EVENT_TYPE_SAVE = 'save';
     var EVENT_TYPE_STATE = 'state';
 
-    var PATTERN_MAIN_FILE = /^((?:[^\\/:\*\?"<>\|]*\/)*)([^\\/:\*\?"<>\|]*)\.java$/i;
+    // original regexp: /^((?:[^\\/:\*\?"<>\|]*\/)*)([^\\/:\*\?"<>\|]*)\.java$/i;
+    var PATTERN_MAIN_FILE = '((?:[^\\\/:\\*\\?"<>\\|]*\\/)*)([^\\\/:\\*\\?"<>\\|]*)\\.(j|J)(a|A)(v|V)(a|A)';
+    var REGEXP_MAIN_FILE = new RegExp('^' + PATTERN_MAIN_FILE + '$');
 
     var FS = ide.getMount();
     var SRC_DIR = 'src';
     var TARGET_DIR = 'target';
     var currentRunConf;
-    var ui = {};
+    var ui = {
+        forms: {
+            inputs: {}
+        }
+    };
 
     var locale = new Locale(i18n);
 
-    function _checkInvalidField(runConf) {
-        var runConfToCheck = runConf;
-        if (!runConf) {
-            var fullPath = ui.readonlyInputBoxes[0].value;
-            var path;
-            if (fullPath) {
-                var matchResult = PATTERN_MAIN_FILE.exec(fullPath);
-                if (matchResult === null) {
-                    return i18n.validationInvalidPath;
-                } else {
-                    path = matchResult[1].split('/').join('.') + matchResult[2];
-                }
-            }
-            runConfToCheck = {
-                name: ui.inputBoxNodes[0].value,
-                project: ui.select.get('value'),
-                path: path,
-                outputDir : TARGET_DIR,
-                srcDir: SRC_DIR
-            };
-        }
+    function _applyFormData() {
+        var matchResult = REGEXP_MAIN_FILE.exec(ui.forms.inputs.path.getValue());
+        var path = (matchResult) ? matchResult[1].split('/').join('.') + matchResult[2] : '';
 
-        if (!runConfToCheck.name) {
-            return i18n.validationNoName;
-        }
-        if (!runConfToCheck.path) {
-            return i18n.validationNoPath;
-        }
-
-        currentRunConf = _.extend(currentRunConf, runConfToCheck);
-
-        return;
+        currentRunConf = _.extend(currentRunConf, {
+            name: ui.forms.inputs.name.getValue(),
+            path: path,
+            project: ui.forms.select.getValue(),
+            outputDir: TARGET_DIR,
+            srcDir: SRC_DIR
+        });
     }
 
     function _pathButtonClicked() {
-        var pathInputBox = ui.readonlyInputBoxes[0];
-        var nameInputBox = ui.inputBoxNodes[0];
-        var project = ui.select.get('value');
+        var pathInputBox = ui.forms.inputs.path;
+        var nameInputBox = ui.forms.inputs.name;
+        var project = ui.forms.select.get('value');
         var initialPath;
         var root;
         var dlg;
@@ -104,8 +100,8 @@ define([
         }
 
         root = ide.getPath() + '/' + project + '/' + SRC_DIR + '/';
-        if (pathInputBox.value) {
-            initialPath = root + pathInputBox.value;
+        if (pathInputBox.getValue()) {
+            initialPath = root + pathInputBox.getValue();
         } else {
             initialPath = root;
         }
@@ -128,15 +124,14 @@ define([
                 }
                 pathSplit = selected[0].split(root);
                 if (pathSplit.length > 0) {
-                    pathInputBox.value = pathSplit[1];
+                    pathInputBox.setValue(pathSplit[1]);
 
                     if (nameInputBox && currentRunConf.__nameGen) {
                         // It is only called when the current run configuration is new and never get any user inputs
-                        nameInputBox.value = pathInputBox.value;
+                        nameInputBox.setValue(pathInputBox.getValue());
                     }
-                    var isValid = !_checkInvalidField();
                     topic.publish('project/run/config/changed', EVENT_TYPE_STATE, currentRunConf, {
-                        isValid: isValid,
+                        isValid: ui.form.validate(),
                         isDirty: true
                     });
                 } else {
@@ -151,10 +146,23 @@ define([
         ui.content.setContent(template);
         if (runConf) {
             var child = ui.content.domNode;
-            ui.inputBoxNodes = $(child).find('.rcw-content-table-inputbox-edit');
-            ui.inputBoxNodes[0].value = runConf.name ? runConf.name : '';
-            ui.readonlyInputBoxes = $(child).find('.rcw-content-table-inputbox-readonly');
-            ui.readonlyInputBoxes[0].value = runConf.path ? (runConf.path.split('.').join('/') + '.java') : '';
+
+            ui.form = new Form({}, 'run-configuration-java-form');
+
+            ui.forms.inputs.name = new ValidationTextBox({
+                required: true,
+                missingMessage: i18n.validationNoName,
+                value: runConf.name ? runConf.name : ''
+            }, 'run-configuration-java-name');
+
+            ui.forms.inputs.path = new ValidationTextBox({
+                required: true,
+                regExp: PATTERN_MAIN_FILE,
+                missingMessage: i18n.validationNoPath,
+                invalidMessage: i18n.validationInvalidPath,
+                value: runConf.path ? (runConf.path.split('.').join('/') + '.java') : '',
+                readonly: true
+            }, 'run-configuration-java-path');
 
             ide.getWorkspaceInfo(function (err, workspaceInfo) {
                 if (!err) {
@@ -167,9 +175,13 @@ define([
                     if (registry.byId('run-configuration-java-project')) {
                         registry.byId('run-configuration-java-project').destroy();
                     }
-                    ui.select = new Select({ options: projects }, 'run-configuration-java-project');
-                    ui.select.startup();
-                    ui.select.set('value', runConf.project);
+                    ui.forms.select = new Select({
+                        options: projects,
+                        required: true,
+                        missingMessage: i18n.validationNoProject
+                    }, 'run-configuration-java-project');
+                    ui.forms.select.startup();
+                    ui.forms.select.setValue(runConf.project);
                 }
             });
 
@@ -177,21 +189,21 @@ define([
             ui.pathButton = $(child).find('.rcw-action-path').get(0);
 
             on(ui.content, 'input, select:change', function () {
-                topic.publish('project/run/config/changed', EVENT_TYPE_STATE, currentRunConf, 
-                              {isValid: !_checkInvalidField(), isDirty: true});
+                topic.publish('project/run/config/changed', EVENT_TYPE_STATE, currentRunConf,
+                        {isValid: ui.form.validate(), isDirty: true});
             });
 
             ui.content.own(
                 on(ui.saveButton, 'click', function () {
-                    var invalidMsg = _checkInvalidField();
-                    if (!invalidMsg) {
+                    if (ui.form.validate()) {
+                        _applyFormData();
                         topic.publish('project/run/config/changed', EVENT_TYPE_SAVE, currentRunConf);
                     } else {
-                        notify.error(invalidMsg);
+                        notify.error(i18n.validationInvalidForm);
                     }
                 }),
                 on(ui.pathButton, 'click', _pathButtonClicked),
-                on(ui.inputBoxNodes[0], 'change', function () {
+                on(ui.forms.inputs.name, 'change', function () {
                     currentRunConf.__nameGen = false;
                 })
             );
@@ -206,13 +218,13 @@ define([
             var filePath = runConf.srcDir + '/' + runConf.path.replace(/\./g, '/') + '.java';
             FS.exec(rootPath, {cmd: 'javac', args: ['-d', runConf.outputDir, filePath]},
                 function (err, stdout, stderr) {
-                    console.debug('###javac', runConf.path, stdout, stderr);
+                    logger.info('###javac', runConf.path, stdout, stderr);
                     topic.publish('#REQUEST.log', stdout);
                     topic.publish('#REQUEST.log', stderr);
                     if (!err && !stderr) {
                         FS.exec(rootPath, {cmd: 'java', args: ['-cp', runConf.outputDir, runConf.path]},
                             function (err, stdout, stderr) {
-                                console.debug('###java', runConf.path, stdout, stderr);
+                                logger.info('###java', runConf.path, stdout, stderr);
                                 topic.publish('#REQUEST.log', stdout);
                                 topic.publish('#REQUEST.log', stderr);
                                 callback(null, runConf);
@@ -226,7 +238,7 @@ define([
             ui.content = content;
             _setTemplate();
             topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, {
-                isValid: !_checkInvalidField(runConf),
+                isValid: ui.form.validate(),
                 isDirty: true
             });
             callback(null, runConf);
@@ -236,22 +248,16 @@ define([
             ui.content = content;
             _setTemplate();
             topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, {
-                isValid: !_checkInvalidField(runConf)
+                isValid: ui.form.validate()
             });
             callback(null, runConf);
         },
         saveConf: function (runConf, callback) {
-            // validation
-            var invalidMsg = _checkInvalidField();
-            if (!invalidMsg) {
-                topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, {
-                    isDirty: false
-                });
-                callback(null, runConf);
-            } else {
-                callback(invalidMsg);
-            }
-            
+            delete currentRunConf.__nameGen;
+            topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, {
+                isDirty: false
+            });
+            callback(null, runConf);
         },
         deleteConf: function (runConfName, callback) {
             callback(null, currentRunConf);

--- a/apps/ide/src/plugins/webida.ide.project-management.run/README.md
+++ b/apps/ide/src/plugins/webida.ide.project-management.run/README.md
@@ -26,13 +26,13 @@ webida.ide.project-management.run
 
 ## Extensions
 
-### webida.ide.project-management.run:type
+### webida.ide.project-management.run:type (Mandatory)
 
 - id(string): run type
-- name(string): type name (label)
+- name(string): name of this type to display (label)
 - hidden(boolean): hiding this type on run configuration UI
 
-### webida.ide.project-management.run:configuration
+### webida.ide.project-management.run:configuration (Mandatory)
 
 - type(string): run type
 - newConf(function(content, newRunConf, callback))
@@ -50,7 +50,7 @@ webida.ide.project-management.run
     - runConfName: run configuration object name to be removed
     - callback(err, runConfName): callback should be called before deleting model
 
-### webida.ide.project-management.run:runner
+### webida.ide.project-management.run:runner (Mandatory)
 
 - type(string): run type
 - run(function(runConf, callback))
@@ -60,10 +60,148 @@ webida.ide.project-management.run
     - runConf: run configuration object
     - callback(err, runConf): callback should be called before starting to debug
 
-### webida.ide.project-management.run:hook
+### webida.ide.project-management.run:hook (Optional)
 
 - type(string): run type
 - beforeLaunch(function(projectInfo, mode, callback))
     - projectInfo: project information of target project
     - mode: 'RUN' or 'DEBUG'
     - callback(err): callback to be called after ending `beforeLaunch`
+
+## Topics
+
+In webida plugin system, These topics enables inter-plugin communications.
+In any plugin that extending `webida.ide.project-management.run:*`, you can send changes on current run configuration to the main plugin `webida.ide.project-management.run`.
+
+### project/run/config/changed
+
+If user have made a change in the extended plugins, this changes should be sent the main plugin using this topic `project/run/config/changed`.
+Then the main plugin will decide to enable/disable its button actions or modify tree.
+There are two candidates for `changedType`. 'state' and 'save'.
+
+``` javascript
+
+// topic.publish('project/run/config/changed', {changedType}, {changedRunConf}\[, {changedState}\]);
+
+define(['dojo/topic'], function (topic) {
+    ...
+    topic.publish('project/run/config/changed', 'state', currentRunConf, { isValid: true, isDirty: true });
+    ...
+    topic.publish('project/run/config/changed', 'save', currentRunConf);
+    ...
+});
+```
+
+#### changedType: state
+
+This type is for notifying changes on current run configuration.
+There are two properties of state that should be sent with this notification.
+
+- isValid (boolean): Are all of the User input values valid?
+- idDirty (boolean): Is any stuff of the run configuration changed and hasn't saved yet? 
+
+#### changedType: save
+
+If the save action(like 'Apply' button), flushing and applying changed things, is occurred in the extended plugin (not main plugin), 
+this topic should be published with the 'save' type and changed run configuration object.
+
+## Usage
+
+First of all, create `plugin.json` file with `extensions` configs in your plugin directory.
+
+* plugin.json
+
+``` javascript
+{
+    ...
+    "extensions": {
+        "webida.ide.project-management.run:type" : [
+            {
+                "id" : "org.webida.run.something",
+                "name" : "Something Application",
+                "hidden": false
+            }
+        ],
+        "webida.ide.project-management.run:configuration" : [
+            {
+                "module" : "plugins/webida.ide.project-management.run.something/plugin",
+                "name" : "Run As Something Application",
+                "type" : "org.webida.run.something",
+                "newConf" : "newConf",
+                "loadConf" : "loadConf",
+                "saveConf" : "saveConf",
+                "deleteConf" : "deleteConf"
+            }
+        ],
+        "webida.ide.project-management.run:runner" : [
+            {
+                "module": "plugins/webida.ide.project-management.run.something/plugin",
+                "type" : "org.webida.run.something",
+                "run": "run"
+            }
+        ]
+    }
+}
+```
+
+And implement these declared methods(newConf, loadConf, saveConf, deleteConf and run) at the declared module `plugin`.
+This is the most simple example to run.
+
+* plugin.js
+
+``` javascript
+define([
+    ...,
+    'dojo/topic',
+    'webida-lib/util/notify'
+], function (
+    ...,
+    topic,
+    notify
+) {
+    function _setTemplate(content) {
+        // create some needed components at the form
+        ...
+        // Set handler for clicking 'apply' button
+        content.own(
+            on(saveButton, 'click', function () {
+                if (form.validate()) {
+                    topic.publish('project/run/config/changed', 'save', currentRunConf);
+                } else {
+                    notify.error(invalidFormMsg);
+                }
+            })
+        );
+        ...
+    }
+    ...
+    return {
+        run: function (runConf, callback) {
+            // execute this runConf
+            callback(null, runConf);
+        },
+        newConf: function (content, runConf, callback) {
+            // make ui form and its components with the runConf at this content element
+            currentRunConf = runConf;
+            _setTemplate(content);
+            topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, {isValid: form.validate(), isDirty: true });
+            callback(null, runConf);
+        },
+        loadConf: function (content, runConf, callback) {
+            // make ui form and its components with the runConf at this content element
+            currentRunConf = runConf;
+            _setTemplate(content);
+            topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, { isValid: form.validate() });
+            callback(null, runConf);
+        },
+        saveConf: function (runConf, callback) {
+            // validation and publish 'save' topic to the main plugin
+            topic.publish('project/run/config/changed', EVENT_TYPE_STATE, runConf, { isDirty: false });
+            callback(null, runConf);
+        },
+        deleteConf: function (runConfName, callback) {
+            callback(null, currentRunConf);
+        }
+    };
+});
+```


### PR DESCRIPTION
#### [IMPROVEMENT] #375 Improve validations on java run configuration

- Use `ValidationTextBox` and its properties(regExp, invalidMessage)
- Use `dijit/form/Form`'s validate() function for validation on whole form

#### [DOCUMENTATION] #535 Update document about run configuration plugin

- add topic and usage descriptions

#### [BUGFIX] RunConf is not saved when 'Run' button is clicked without clicking 'Apply'.

- This problem caused by the previous PR(#817).
- For validation on async item (e.g. project), using dojo.store implementations, `Observable` and `Memory`
