### PR TITLE
[BUGFIX](#763)Cannot select name of directory to rename.

### DIFF
--- a/common/src/webida/plugins/workspace/Node.js
+++ b/common/src/webida/plugins/workspace/Node.js
@@ -1337,6 +1337,8 @@ define(['require',
         var extLength = self.name.lastIndexOf('.');
         if (extLength > 0 && extLength < (self.name.length - 1)) {
             $input[0].setSelectionRange(0, extLength);
+        } else if (extLength === -1) {
+            $input[0].setSelectionRange(0, self.name.length);
         }
 
         $input.on('focusout', function () {


### PR DESCRIPTION
[DESC.] If the name of selected file/directory contains no '.', then no string is selected. We changed it to select entire string.