### PR TITLE
[TASK] Fix path problems caused by updated tern

### DIFF
--- a/apps/ide/src/plugins/webida.editor.code-editor.content-assist.tern/tern-plugin-dojojs.js
+++ b/apps/ide/src/plugins/webida.editor.code-editor.content-assist.tern/tern-plugin-dojojs.js
@@ -52,8 +52,8 @@ function (infer, tern, walk, path) {
             if (baseurl && baseurl[0] !== '/') {
                 baseurl = path.getDirPath(infer.cx().curOrigin) + baseurl;
             }
-            if (options.baseUrl !== baseurl) {
-                options.baseUrl = baseurl;
+            if (options.baseURL !== baseurl) {
+                options.baseURL = baseurl;
                 return true;
             }
         }

--- a/apps/ide/src/plugins/webida.editor.code-editor.content-assist.tern/tern-server-starter.js
+++ b/apps/ide/src/plugins/webida.editor.code-editor.content-assist.tern/tern-server-starter.js
@@ -25,15 +25,6 @@ function (require, topic, _, ide, codemirror, pathUtil) {
 
     var ternServerStarter = {};
 
-    function moveToPosition(data) {
-        require(['plugins/webida.editor.text-editor/TextEditorPart'], function (TextEditorPart) {
-            TextEditorPart.moveTo(TextEditorPart.pushCursorLocation(data.file, {
-                row: data.start.line,
-                col: data.start.ch
-            }, true));
-        });
-    }
-
     function hasActiveCompletion(cm) {
         return (cm.state.completionActive && cm.state.completionActive.widget);
     }
@@ -75,7 +66,7 @@ function (require, topic, _, ide, codemirror, pathUtil) {
     WorkerServer.prototype.getFile = function (filepath, c) {
         this.assist.send({mode: this.mode, type: 'getFile', filepath: filepath}, c);
     };
-    
+
     function Server(serverId) {
         this.serverId = serverId;
         this.server = null;
@@ -119,12 +110,19 @@ function (require, topic, _, ide, codemirror, pathUtil) {
             server = new WorkerServer(filepath, options.langMode, options.engineName);
         } else {
             server = new Server(filepath);
-        } 
+        }
 
         server.start(function () {
             server.ternAddon = new codemirror.TernServer({
                 server: server,
-                moveToPosition: moveToPosition,
+                moveToPosition: function (data) {
+                    require(['plugins/webida.editor.text-editor/TextEditorPart'], function (TextEditorPart) {
+                        TextEditorPart.moveTo(TextEditorPart.pushCursorLocation(data.file, {
+                            row: data.start.line,
+                            col: data.start.ch
+                        }, true));
+                    });
+                },
                 onShowArgHints: onShowArgHints
             });
 

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
         "eventEmitter": "~4.2.11",
         "bootstrap-treeview": "~1.2.0",
         "calcium": "git://github.com/webida/calcium#415ebc22cc6a09457bb9e7445f149061787920fe",
-        "tern": "git://github.com/webida/tern#856aa4c3863f89fef52d9e586b1eb42107029de5",
+        "tern": "git://github.com/webida/tern#488e4d533a0cf64ce1b14a78f5dd13429b676285",
         "smalot-bootstrap-datetimepicker": "~2.3.4",
         "es6-shim": "~0.33.9",
         "term.js": "git://github.com/chjj/term.js.git#~v0.0.7"


### PR DESCRIPTION
[DESC.]
For each of the commits, 
1) This commit makes tern use correct base url in dojojs plugin.
2) A simple refactoring
3) While tern uses relative paths, file-server and others should use absolute paths.
Therefore, I applied getAbsPath for path data coming from tern,
and applied getRelPath for path data going into tern.
4) I needed to modify tern to resolve #808. This commit updates the commit id of tern in bower.json