### PR TITLE
[TASK] Use tern fixed for #847.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "eventEmitter": "~4.2.11",
     "bootstrap-treeview": "~1.2.0",
     "calcium": "git://github.com/webida/calcium#415ebc22cc6a09457bb9e7445f149061787920fe",
-    "tern": "git://github.com/webida/tern#488e4d533a0cf64ce1b14a78f5dd13429b676285",
+    "tern": "git://github.com/webida/tern#74bae02d260c609c4b63d9d169c9b7e07aa9e705",
     "smalot-bootstrap-datetimepicker": "~2.3.4",
     "es6-shim": "~0.33.9",
     "term.js": "git://github.com/chjj/term.js.git#~v0.0.7",


### PR DESCRIPTION
[DESC.] #847 was caused by tern that tries to analyze a file whose `text` value is `null`.
So, I fixed tern so that it does not analyze such invalid files.