### PR TITLE
[BUGFIX] Additional path conversion in request to tern.

### DIFF
--- a/apps/ide/src/plugins/webida.editor.code-editor.content-assist.tern/js-hint-server.js
+++ b/apps/ide/src/plugins/webida.editor.code-editor.content-assist.tern/js-hint-server.js
@@ -246,9 +246,15 @@ function (require, _, pathUtil, tern, fileServer, reference, browserText,
                 }
             }
 
-            // Since tern uses relative paths,
-            if (body.query.file) {
+            // Since tern uses relative paths, we need to convert the paths.
+            // A file name starting with '#' is created by tern addon and we should not convert such file name.
+            if (body.query.file && !/^#/.test(body.query.file)) {
                 body.query.file = getRelPath(server.tern.projectDir, body.query.file);
+            }
+            if (body.files) {
+                body.files.forEach(function (file) {
+                    file.name = getRelPath(server.tern.projectDir, file.name);
+                });
             }
 
             server.tern.request(body, function (error, data) {

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "eventEmitter": "~4.2.11",
     "bootstrap-treeview": "~1.2.0",
     "calcium": "git://github.com/webida/calcium#415ebc22cc6a09457bb9e7445f149061787920fe",
-    "tern": "git://github.com/webida/tern#74bae02d260c609c4b63d9d169c9b7e07aa9e705",
+    "tern": "git://github.com/webida/tern#ab9f92a23d9f8d09071c3549b33ff40dcfb27ed3",
     "smalot-bootstrap-datetimepicker": "~2.3.4",
     "es6-shim": "~0.33.9",
     "term.js": "git://github.com/chjj/term.js.git#~v0.0.7",


### PR DESCRIPTION
[DESC.]
- Since completion request can contain absolute paths data in `body.files`, we convert them to relative paths.
- tern is additionally fixed for #847.