### PR TITLE
[BUGFIX] (#854) Prevent from chrome freezing when 'Find in Files' runs

### DIFF
--- a/common/src/webida/plugins/fs-commands/fs-commands.js
+++ b/common/src/webida/plugins/fs-commands/fs-commands.js
@@ -43,6 +43,9 @@ define([
     'dojo/Deferred',                            // Deferred
     'dojo/store/Memory',                        // Memory
     'dojo/store/Observable',                    // Observable
+    'dijit/form/Button',
+    'dijit/form/CheckBox',
+    'dijit/form/ComboBox',
     'dijit/tree/ObjectStoreModel',              // ObjectStoreModel
     'dijit/Tree',                               // Tree
     'dijit/registry',                           // reg
@@ -75,6 +78,9 @@ define([
     Deferred,
     Memory,
     Observable,
+    Button,
+    CheckBox,
+    ComboBox,
     ObjectStoreModel,
     Tree,
     reg,
@@ -196,7 +202,7 @@ define([
                 { caption: i18n.cancel, methodOnClick: 'hide' }
             ],
             methodOnEnter: 'onOkay',
-
+            style: 'width:500px;',
             title: i18n.findInFiles,
 
             refocus: false,
@@ -346,21 +352,29 @@ define([
             },
 
             initElements: function () {
+                var defaults = {
+                    searchAttr: 'name',
+                    missingMessage: i18n.valueRequired,
+                    ignoreCase: true,
+                    autoComplete: false,
+                    queryExpr: '*${0}*',
+                    style: 'width: 300px'
+                };
                 // pattern of keywords to find
-                patternComboElem = reg.byId('sfDojoComboBoxPatternToFind');
+                patternComboElem = new ComboBox(defaults, 'sfDojoComboBoxPatternToFind');
 
-                asRegExBtElem = reg.byId('sfDojoCheckBoxRegEx');
-                ignorCaseBtElem = reg.byId('sfDojoCheckBoxIgnoreCase');
-                wholewordBtElem = reg.byId('sfDojoCheckBoxWholeWords');
+                asRegExBtElem = new CheckBox({}, 'sfDojoCheckBoxRegEx');
+                ignorCaseBtElem = new CheckBox({}, 'sfDojoCheckBoxIgnoreCase');
+                wholewordBtElem = new CheckBox({}, 'sfDojoCheckBoxWholeWords');
 
                 // search target directory
-                folderComboElem = reg.byId('sfDojoComboBoxRecentFolders');
-
+                folderComboElem = new ComboBox(defaults, 'sfDojoComboBoxRecentFolders');
+                folderComboElem.set('style', 'width: 238px');
                 // additional find options
-                exFoldersComboElem = reg.byId('sfDojoComboBoxFoldersToExclude');
-                exFoldersAsRegExBtElem = reg.byId('sfDojoCheckBoxExcludeRegEx');
-                inFilesComboElem = reg.byId('sfDojoComboBoxFilesToInclude');
-                inFilesAsRegExBtElem = reg.byId('sfDojoCheckBoxFilesRegEx');
+                exFoldersComboElem = new ComboBox(defaults, 'sfDojoComboBoxFoldersToExclude');
+                exFoldersAsRegExBtElem = new CheckBox({}, 'sfDojoCheckBoxExcludeRegEx');
+                inFilesComboElem = new ComboBox(defaults, 'sfDojoComboBoxFilesToInclude');
+                inFilesAsRegExBtElem = new CheckBox({}, 'sfDojoCheckBoxFilesRegEx');
             }, // initElements close
 
             restoreElementValues: function () {
@@ -397,23 +411,12 @@ define([
 
             setElements: function () {
                 // setting element value
-                var defaults = {
-                    searchAttr: 'name',
-                    missingMessage: i18n.valueRequired,
-                    ignoreCase: true,
-                    autoComplete: false,
-                    queryExpr: '*${0}*',
-                };
-
                 var required = {
                     required: true,
                     missingMessage: i18n.valueRequired
                 };
 
-                patternComboElem.set(defaults);
                 patternComboElem.set(required);
-
-                folderComboElem.set(defaults);
                 folderComboElem.set(required);
 
                 // override displayMessage function
@@ -453,14 +456,12 @@ define([
                     }
                 };
 
-                exFoldersComboElem.set(defaults);
-                inFilesComboElem.set(defaults);
             }, // setElements close
 
             onLoad: function () {
                 // event bind, dojo element
-                var id = reg.byId('sfDojoFormBrowse');
-                dojo.connect(id, 'onClick', this.onBrowse);
+                var button = new Button({}, 'sfDojoFormBrowse');
+                dojo.connect(button, 'onClick', this.onBrowse);
 
                 // init elements
                 this.initElements();
@@ -503,8 +504,6 @@ define([
             tooltipHandle(folderComboElem, fTooltipState);
         });
 
-        handleFileInFilesDlg.set('doLayout', false);
-        //handleFileInFilesDlg.set('content', sFilesForm);
         handleFileInFilesDlg.setContentArea(sFilesForm);
 
         locale.convertMessage(i18n, 'data-message');
@@ -600,7 +599,7 @@ define([
     }
 
     var gotoFileData = {
-        lastDir : ide.getPath() + '/'
+        lastDir: ide.getPath() + '/'
     };
 
     function gotoFileInCurDir() {
@@ -630,7 +629,7 @@ define([
             goToFile: function () {
                 var gotoFileInput = reg.byId('FsCommandFileToGoInput');
                 var text = gotoFileInput.value;
-                var bExist = this.inputStore.query({ id: text }).length === 1 ? true : false;
+                var bExist = this.inputStore.query({ id: text }).length === 1;
 
                 if (bExist) {
                     topic.publish('editor/open', text);

--- a/common/src/webida/plugins/fs-commands/layer/searchFilesForm.html
+++ b/common/src/webida/plugins/fs-commands/layer/searchFilesForm.html
@@ -1,62 +1,80 @@
-<div id='sfDojoWindow' data-dojo-type='dijit/layout/ContentPane' style='width:500px; padding-top: 0'>
-    <style type='text/css'>
-        .find_in_files_border {
+<div id="sfDojoWindow">
+    <style type="text/css">
+        .desc {
+            margin-top: 5px;
+            margin-bottom: 10px;
+        }
+
+        .searchFilesFormFields {
             border: 1px #797979 solid;
             padding: 7px 10px;
-                        margin: 2px 0;
-                        border-radius: 5px;
+            margin: 2px 0 10px 0;
+            border-radius: 5px;
         }
 
-        .find_in_files_input {
-            width: 100%;
+        .searchFilesFormFields legend {
+            font-weight: bold;
         }
 
-        .desc {
-                margin-top: 5px;
-                margin-bottom: 15px;
+        .searchFilesForm label {
+            display: inline-block;
+            width: 145px;
         }
 
-        .group_label {
-                font-weight: bold;
-                color: #494949;
+        .searchFilesForm fieldset > div {
+            margin-bottom: 5px;
         }
 
-        .claro .buttons {
-                margin-right: 8px;
+        .searchFilesForm label.labelForTextField {
+            font-weight: bold;
         }
-
-        .claro .buttons > .dijitButtonNode {
-                padding: 4px 10px;
-        }
-
     </style>
-    <form>
+    <form class="searchFilesForm">
         <p class="desc" data-message="searchFilesDesc"> Fill in the following form to search files for a keyword. </p>
 
-        <label class="group_label" data-message="requiredFields"> Required fields </label>
-        <div class='find_in_files_border'>
-            <label data-message="keywordToFind"> Keyword to find </label> <input id="sfDojoCheckBoxRegEx" data-dojo-type='dijit/form/CheckBox' style="margin-left: 200px" tabindex="2"/>
-            <label data-message="asARegularExpression"> as a regular expression </label>
-            <select id='sfDojoComboBoxPatternToFind' data-dojo-type='dijit/form/ComboBox' class='find_in_files_input' tabindex="1"></select>
-            <br> <br>
-            <label data-message="baseDirToSearch"> Base directory to search </label> <br>
-            <select id='sfDojoComboBoxRecentFolders' data-dojo-type='dijit/form/ComboBox' style='width:407px' tabindex="3"></select>
-                        <button id='sfDojoFormBrowse' data-dojo-type='dijit/form/Button' type='button' style="margin-left: 4px" tabindex="4" data-message="browse"> Browse </button>
-        </div>
-        <br>
+        <fieldset class="searchFilesFormFields">
+            <legend>General</legend>
+            <div>
+                <label data-message="keywordToFind" for="sfDojoCheckBoxRegEx" class="labelForTextField">Keyword to find</label>
+                <select id="sfDojoComboBoxPatternToFind" tabindex="1"></select>
+            </div>
+            <div>
+                <input id="sfDojoCheckBoxRegEx" tabindex="2"/>
+                <label for="sfDojoComboBoxPatternToFind" data-message="asARegularExpression"> as a regular expression </label>
+            </div>
+            <div>
+                <input id="sfDojoCheckBoxIgnoreCase" tabindex="5" />
+                <label for="sfDojoCheckBoxIgnoreCase" data-message="ignoreCase"> Ignore case</label>
+            </div>
+            <div>
+                <input id="sfDojoCheckBoxWholeWords" tabindex="6" />
+                <label for="sfDojoCheckBoxWholeWords" data-message="wholeWordsOnly"> Whole words only</label>
+            </div>
+        </fieldset>
 
-        <label class="group_label" data-message="optionalFields"> Optional fields </label>
-        <div class='find_in_files_border'>
-            <input id="sfDojoCheckBoxIgnoreCase" data-dojo-type='dijit/form/CheckBox' tabindex="5" /><label style="margin-right: 20px" data-message="ignoreCase"> Ignore case</label>
-            <input id="sfDojoCheckBoxWholeWords" data-dojo-type='dijit/form/CheckBox' tabindex="6" /><label data-message="wholeWordsOnly"> Whole words only</label>
-            <br> <br>
-            <label data-message="excludedDirs"> Excluded directories </label> <input id="sfDojoCheckBoxExcludeRegEx" data-dojo-type='dijit/form/CheckBox' style="margin-left: 120px" tabindex="2"/>
-            <label data-message="asARegularExpression"> as a regular expression </label>
-            <select id='sfDojoComboBoxFoldersToExclude' data-dojo-type='dijit/form/ComboBox' class='find_in_files_input' tabindex="7"></select>
-            <br> <br>
-            <label data-message="searchedFiles"> Searched files </label> <input id="sfDojoCheckBoxFilesRegEx" data-dojo-type='dijit/form/CheckBox' style="margin-left: 152px" tabindex="2"/>
-            <label data-message="asARegularExpression"> as a regular expression </label>
-            <select id='sfDojoComboBoxFilesToInclude' data-dojo-type='dijit/form/ComboBox' class='find_in_files_input' tabindex="8"></select>
-        </div>
+        <fieldset class="searchFilesFormFields">
+            <legend>Scope</legend>
+            <div>
+                <label for="sfDojoComboBoxRecentFolders" data-message="baseDirToSearch" class="labelForTextField">Base directory to search </label>
+                <select id="sfDojoComboBoxRecentFolders" tabindex="3"></select>
+                <button id="sfDojoFormBrowse" type="button" style="margin-left: 4px" tabindex="4" data-message="browse"> Browse </button>
+            </div>
+            <div>
+                <label data-message="excludedDirs" class="labelForTextField">Excluded directories </label>
+                <select id="sfDojoComboBoxFoldersToExclude"  tabindex="7"></select>
+            </div>
+            <div>
+                <input id="sfDojoCheckBoxExcludeRegEx" tabindex="2"/>
+                <label data-message="asARegularExpression"> as a regular expression </label>
+            </div>
+            <div>
+                <label data-message="searchedFiles" class="labelForTextField"> Searched files </label>
+                <select id="sfDojoComboBoxFilesToInclude" tabindex="8"></select>
+            </div>
+            <div>
+                <input id="sfDojoCheckBoxFilesRegEx" tabindex="2"/>
+                <label data-message="asARegularExpression"> as a regular expression </label>
+            </div>
+        </fieldset>
     </form>
 </div>


### PR DESCRIPTION
- replace initializing dojo widget with programmatic way
- change markup of the template
- I could not find what is the real reason of this problem. The strongest suspects are `ComboBox` and "LAYOUT" (including its style) of the template.