### PR TITLE
[BUGFIX] (#865) Too many 404 errors for tern requests

### DIFF
--- a/apps/ide/src/plugins/webida.editor.code-editor/content-assist/assist.js
+++ b/apps/ide/src/plugins/webida.editor.code-editor/content-assist/assist.js
@@ -31,7 +31,7 @@ define([
 
     function getRemoteFile(path, c) {
         //ide.getMount().readFile(path, function (error, content) {
-        ide.getFSCache().readFile(path, function (error, content) {
+        ide.getFSCache().readFile(path, {mayNotExist: true}, function (error, content) {
             if (content === undefined) {
                 content = null;
             }


### PR DESCRIPTION
[DESC.]
- add an option (e.g. mayNotExist) to the readFile API
- If this options is true, server will response with 204(No Conent) status code in error case of 404.