### PR TITLE
[BUGFIX] Bug fixes on run configuration and preference dialog

### DIFF
--- a/apps/ide/src/plugins/webida.ide.project-management.run/view-controller.js
+++ b/apps/ide/src/plugins/webida.ide.project-management.run/view-controller.js
@@ -251,7 +251,7 @@ define([
                 }
             },
             runConf: function () {
-                delegator.saveConf(current.runConf, function (err, runConf) {
+                function _run(err, runConf) {
                     if (!err) {
                         switch (mode) {
                             case runConfManager.MODE.RUN_MODE:
@@ -263,7 +263,12 @@ define([
                         }
                         ui.dialog.hide();
                     }
-                });
+                }
+                if (current.runConf._dirty) {
+                    delegator.saveConf(current.runConf, _run);
+                } else {
+                    _run(null, current.runConf);
+                }
             },
             refocus: false,
             title: title,

--- a/apps/ide/src/plugins/webida.preference/preference-manager.js
+++ b/apps/ide/src/plugins/webida.preference/preference-manager.js
@@ -272,6 +272,13 @@ define([
             });
         },
 
+        undoAllChanges: function (scope, scopeInfo) {
+            var storesByScope = this.getStoresByScope(scope, scopeInfo);
+            _.forEach(storesByScope, function (store) {
+                store.undoChanges();
+            });
+        },
+
         /**
          * Get all preference file list
          * @return {Promise}

--- a/apps/ide/src/plugins/webida.preference/preference-store.js
+++ b/apps/ide/src/plugins/webida.preference/preference-store.js
@@ -234,6 +234,13 @@ define([
         },
 
         /**
+         * Undo changes from the last appliedValues
+         */
+        undoChanges: function () {
+            this.initialValues(this.defaultValues, this.appliedValues);
+        },
+
+        /**
          * set override option
          * @param {boolean} override - override set or not
          */

--- a/apps/ide/src/plugins/webida.preference/view-controller.js
+++ b/apps/ide/src/plugins/webida.preference/view-controller.js
@@ -231,6 +231,7 @@ define([
                             notify.error(err);
                         }
                         module.isOpened = false;
+                        preferenceManager.undoAllChanges(scope, scopeInfo);
                     });
                 }
             });


### PR DESCRIPTION
##### #851 'Cancel' operation works weird in Preferences
- Undo all changes while closing preference dialog

##### #863 Unnecessary pop-up is occurred in run configuration dialog
-  If there's no changes, the execution of 'Run' button will not produce the 'successful save' message.

Related issue #851, #863